### PR TITLE
Better handling of gendered/genderless Pokemon

### DIFF
--- a/pokecat/__init__.py
+++ b/pokecat/__init__.py
@@ -217,9 +217,9 @@ def populate_pokeset(pokeset, skip_ev_check=False):
 
     # check gender
     gender = pokeset["gender"]
-    expected_gender = pokeset["species"]["gender"]
+    expected_genders = pokeset["species"]["genders"]
     if gender is None:
-        gender = expected_gender
+        gender = expected_genders.copy()
     if gender == "mf":
         gender = ["m", "f"]
     if not isinstance(gender, list):
@@ -229,8 +229,8 @@ def populate_pokeset(pokeset, skip_ev_check=False):
     for gender_single in gender:
         if gender_single not in ("m", "f", None):
             raise ValueError("gender can only be 'm', 'f' or not set (null), but not %s" % (gender_single,))
-        if not ((expected_gender and gender_single) and (gender_single in expected_gender) or gender_single == expected_gender):
-            raise ValueError(f"Incorrect gender for {pokeset['species']['name']}")
+        if gender_single not in expected_genders:
+            raise ValueError(f"Invalid gender for {pokeset['species']['name']}")
     if len(set(gender)) < len(gender):
         raise ValueError("All genders supplied must be unique: %s" % ", ".join(gender))
     pokeset["gender"] = gender

--- a/pokecat/__init__.py
+++ b/pokecat/__init__.py
@@ -78,10 +78,10 @@ def populate_pokeset(pokeset, skip_ev_check=False):
     # special cases. I couldn't come up with a structure that wouldn't
     # just feel forced. It could be better, but it could also be worse,
     # and to be honest it's easy enough to maintain (for me at least).
-    
+
     # make deepcopy to not modify original data
     pokeset = deepcopy(pokeset)
-    
+
     # check if there are wrongly capitalized keys
     for key, value in list(pokeset.items()):
         key_lower = key.lower()
@@ -217,6 +217,11 @@ def populate_pokeset(pokeset, skip_ev_check=False):
 
     # check gender
     gender = pokeset["gender"]
+    expected_gender = pokeset["species"]["gender"]
+    if gender is None:
+        gender = expected_gender
+    if gender == "mf":
+        gender = ["m", "f"]
     if not isinstance(gender, list):
         gender = [gender]
     if not gender:
@@ -224,8 +229,8 @@ def populate_pokeset(pokeset, skip_ev_check=False):
     for gender_single in gender:
         if gender_single not in ("m", "f", None):
             raise ValueError("gender can only be 'm', 'f' or not set (null), but not %s" % (gender_single,))
-    if len(gender) > 1 and None in gender:
-        raise ValueError("non-gender cannot be mixed with m/f")
+        if not ((expected_gender and gender_single) and (gender_single in expected_gender) or gender_single == expected_gender):
+            raise ValueError(f"Incorrect gender for {pokeset['species']['name']}")
     if len(set(gender)) < len(gender):
         raise ValueError("All genders supplied must be unique: %s" % ", ".join(gender))
     pokeset["gender"] = gender
@@ -584,7 +589,7 @@ def instantiate_pokeset(pokeset):
         for move in instance["moves"]:
             # extra displayname, might differ due to special cases
             move["displayname"] = move["name"]
-            
+
             # special case: Hidden Power. Fix type, power and displayname
             if move["name"] == "Hidden Power":
                 a, b, c, d, e, f = [ivs[stat] % 2 for stat in ("hp", "atk", "def", "spe", "spA", "spD")]
@@ -727,4 +732,3 @@ def redact_pokeset_data(pokemon):
     pokemon['moves'][0]['power'] = 0
     pokemon['moves'][0]['accuracy'] = 0
     pokemon['tags'] = []
-

--- a/pokecat/gen4data/pokedex.json
+++ b/pokecat/gen4data/pokedex.json
@@ -16,7 +16,7 @@
         },
         "name": "Bulbasaur",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 2,
@@ -34,7 +34,7 @@
         },
         "name": "Ivysaur",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 3,
@@ -52,7 +52,7 @@
         },
         "name": "Venusaur",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 4,
@@ -69,7 +69,7 @@
         },
         "name": "Charmander",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 5,
@@ -86,7 +86,7 @@
         },
         "name": "Charmeleon",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 6,
@@ -104,7 +104,7 @@
         },
         "name": "Charizard",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 7,
@@ -121,7 +121,7 @@
         },
         "name": "Squirtle",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 8,
@@ -138,7 +138,7 @@
         },
         "name": "Wartortle",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 9,
@@ -155,7 +155,7 @@
         },
         "name": "Blastoise",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 10,
@@ -172,7 +172,7 @@
         },
         "name": "Caterpie",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 11,
@@ -189,7 +189,7 @@
         },
         "name": "Metapod",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 12,
@@ -207,7 +207,7 @@
         },
         "name": "Butterfree",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 13,
@@ -225,7 +225,7 @@
         },
         "name": "Weedle",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 14,
@@ -243,7 +243,7 @@
         },
         "name": "Kakuna",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 15,
@@ -261,7 +261,7 @@
         },
         "name": "Beedrill",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 16,
@@ -279,7 +279,7 @@
         },
         "name": "Pidgey",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 17,
@@ -297,7 +297,7 @@
         },
         "name": "Pidgeotto",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 18,
@@ -315,7 +315,7 @@
         },
         "name": "Pidgeot",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 19,
@@ -332,7 +332,7 @@
         },
         "name": "Rattata",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 20,
@@ -349,7 +349,7 @@
         },
         "name": "Raticate",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 21,
@@ -367,7 +367,7 @@
         },
         "name": "Spearow",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 22,
@@ -385,7 +385,7 @@
         },
         "name": "Fearow",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 23,
@@ -402,7 +402,7 @@
         },
         "name": "Ekans",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 24,
@@ -419,7 +419,7 @@
         },
         "name": "Arbok",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 25,
@@ -436,7 +436,7 @@
         },
         "name": "Pikachu",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 26,
@@ -453,7 +453,7 @@
         },
         "name": "Raichu",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 27,
@@ -470,7 +470,7 @@
         },
         "name": "Sandshrew",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 28,
@@ -487,7 +487,7 @@
         },
         "name": "Sandslash",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 29,
@@ -504,7 +504,7 @@
         },
         "name": "Nidoran\u2640",
         "color": "Blue",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 30,
@@ -521,7 +521,7 @@
         },
         "name": "Nidorina",
         "color": "Blue",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 31,
@@ -539,7 +539,7 @@
         },
         "name": "Nidoqueen",
         "color": "Blue",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 32,
@@ -556,7 +556,7 @@
         },
         "name": "Nidoran\u2642",
         "color": "Purple",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 33,
@@ -573,7 +573,7 @@
         },
         "name": "Nidorino",
         "color": "Purple",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 34,
@@ -591,7 +591,7 @@
         },
         "name": "Nidoking",
         "color": "Purple",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 35,
@@ -608,7 +608,7 @@
         },
         "name": "Clefairy",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 36,
@@ -625,7 +625,7 @@
         },
         "name": "Clefable",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 37,
@@ -642,7 +642,7 @@
         },
         "name": "Vulpix",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 38,
@@ -659,7 +659,7 @@
         },
         "name": "Ninetales",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 39,
@@ -676,7 +676,7 @@
         },
         "name": "Jigglypuff",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 40,
@@ -693,7 +693,7 @@
         },
         "name": "Wigglytuff",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 41,
@@ -711,7 +711,7 @@
         },
         "name": "Zubat",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 42,
@@ -729,7 +729,7 @@
         },
         "name": "Golbat",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 43,
@@ -747,7 +747,7 @@
         },
         "name": "Oddish",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 44,
@@ -765,7 +765,7 @@
         },
         "name": "Gloom",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 45,
@@ -783,7 +783,7 @@
         },
         "name": "Vileplume",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 46,
@@ -801,7 +801,7 @@
         },
         "name": "Paras",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 47,
@@ -819,7 +819,7 @@
         },
         "name": "Parasect",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 48,
@@ -837,7 +837,7 @@
         },
         "name": "Venonat",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 49,
@@ -855,7 +855,7 @@
         },
         "name": "Venomoth",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 50,
@@ -872,7 +872,7 @@
         },
         "name": "Diglett",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 51,
@@ -889,7 +889,7 @@
         },
         "name": "Dugtrio",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 52,
@@ -906,7 +906,7 @@
         },
         "name": "Meowth",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 53,
@@ -923,7 +923,7 @@
         },
         "name": "Persian",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 54,
@@ -940,7 +940,7 @@
         },
         "name": "Psyduck",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 55,
@@ -957,7 +957,7 @@
         },
         "name": "Golduck",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 56,
@@ -974,7 +974,7 @@
         },
         "name": "Mankey",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 57,
@@ -991,7 +991,7 @@
         },
         "name": "Primeape",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 58,
@@ -1008,7 +1008,7 @@
         },
         "name": "Growlithe",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 59,
@@ -1025,7 +1025,7 @@
         },
         "name": "Arcanine",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 60,
@@ -1042,7 +1042,7 @@
         },
         "name": "Poliwag",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 61,
@@ -1059,7 +1059,7 @@
         },
         "name": "Poliwhirl",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 62,
@@ -1077,7 +1077,7 @@
         },
         "name": "Poliwrath",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 63,
@@ -1094,7 +1094,7 @@
         },
         "name": "Abra",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 64,
@@ -1111,7 +1111,7 @@
         },
         "name": "Kadabra",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 65,
@@ -1128,7 +1128,7 @@
         },
         "name": "Alakazam",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 66,
@@ -1145,7 +1145,7 @@
         },
         "name": "Machop",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 67,
@@ -1162,7 +1162,7 @@
         },
         "name": "Machoke",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 68,
@@ -1179,7 +1179,7 @@
         },
         "name": "Machamp",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 69,
@@ -1197,7 +1197,7 @@
         },
         "name": "Bellsprout",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 70,
@@ -1215,7 +1215,7 @@
         },
         "name": "Weepinbell",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 71,
@@ -1233,7 +1233,7 @@
         },
         "name": "Victreebel",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 72,
@@ -1251,7 +1251,7 @@
         },
         "name": "Tentacool",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 73,
@@ -1269,7 +1269,7 @@
         },
         "name": "Tentacruel",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 74,
@@ -1287,7 +1287,7 @@
         },
         "name": "Geodude",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 75,
@@ -1305,7 +1305,7 @@
         },
         "name": "Graveler",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 76,
@@ -1323,7 +1323,7 @@
         },
         "name": "Golem",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 77,
@@ -1340,7 +1340,7 @@
         },
         "name": "Ponyta",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 78,
@@ -1357,7 +1357,7 @@
         },
         "name": "Rapidash",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 79,
@@ -1375,7 +1375,7 @@
         },
         "name": "Slowpoke",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 80,
@@ -1393,7 +1393,7 @@
         },
         "name": "Slowbro",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 81,
@@ -1411,7 +1411,7 @@
         },
         "name": "Magnemite",
         "color": "Gray",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 82,
@@ -1429,7 +1429,7 @@
         },
         "name": "Magneton",
         "color": "Gray",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 83,
@@ -1447,7 +1447,7 @@
         },
         "name": "Farfetch'd",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 84,
@@ -1465,7 +1465,7 @@
         },
         "name": "Doduo",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 85,
@@ -1483,7 +1483,7 @@
         },
         "name": "Dodrio",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 86,
@@ -1500,7 +1500,7 @@
         },
         "name": "Seel",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 87,
@@ -1518,7 +1518,7 @@
         },
         "name": "Dewgong",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 88,
@@ -1535,7 +1535,7 @@
         },
         "name": "Grimer",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 89,
@@ -1552,7 +1552,7 @@
         },
         "name": "Muk",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 90,
@@ -1569,7 +1569,7 @@
         },
         "name": "Shellder",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 91,
@@ -1587,7 +1587,7 @@
         },
         "name": "Cloyster",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 92,
@@ -1605,7 +1605,7 @@
         },
         "name": "Gastly",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 93,
@@ -1623,7 +1623,7 @@
         },
         "name": "Haunter",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 94,
@@ -1641,7 +1641,7 @@
         },
         "name": "Gengar",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 95,
@@ -1659,7 +1659,7 @@
         },
         "name": "Onix",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 96,
@@ -1676,7 +1676,7 @@
         },
         "name": "Drowzee",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 97,
@@ -1693,7 +1693,7 @@
         },
         "name": "Hypno",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 98,
@@ -1710,7 +1710,7 @@
         },
         "name": "Krabby",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 99,
@@ -1727,7 +1727,7 @@
         },
         "name": "Kingler",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 100,
@@ -1744,7 +1744,7 @@
         },
         "name": "Voltorb",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 101,
@@ -1761,7 +1761,7 @@
         },
         "name": "Electrode",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 102,
@@ -1779,7 +1779,7 @@
         },
         "name": "Exeggcute",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 103,
@@ -1797,7 +1797,7 @@
         },
         "name": "Exeggutor",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 104,
@@ -1814,7 +1814,7 @@
         },
         "name": "Cubone",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 105,
@@ -1831,7 +1831,7 @@
         },
         "name": "Marowak",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 106,
@@ -1848,7 +1848,7 @@
         },
         "name": "Hitmonlee",
         "color": "Brown",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 107,
@@ -1865,7 +1865,7 @@
         },
         "name": "Hitmonchan",
         "color": "Brown",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 108,
@@ -1882,7 +1882,7 @@
         },
         "name": "Lickitung",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 109,
@@ -1899,7 +1899,7 @@
         },
         "name": "Koffing",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 110,
@@ -1916,7 +1916,7 @@
         },
         "name": "Weezing",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 111,
@@ -1934,7 +1934,7 @@
         },
         "name": "Rhyhorn",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 112,
@@ -1952,7 +1952,7 @@
         },
         "name": "Rhydon",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 113,
@@ -1969,7 +1969,7 @@
         },
         "name": "Chansey",
         "color": "Pink",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 114,
@@ -1986,7 +1986,7 @@
         },
         "name": "Tangela",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 115,
@@ -2003,7 +2003,7 @@
         },
         "name": "Kangaskhan",
         "color": "Brown",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 116,
@@ -2020,7 +2020,7 @@
         },
         "name": "Horsea",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 117,
@@ -2037,7 +2037,7 @@
         },
         "name": "Seadra",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 118,
@@ -2054,7 +2054,7 @@
         },
         "name": "Goldeen",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 119,
@@ -2071,7 +2071,7 @@
         },
         "name": "Seaking",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 120,
@@ -2088,7 +2088,7 @@
         },
         "name": "Staryu",
         "color": "Brown",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 121,
@@ -2106,7 +2106,7 @@
         },
         "name": "Starmie",
         "color": "Purple",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 122,
@@ -2123,7 +2123,7 @@
         },
         "name": "Mr. Mime",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 123,
@@ -2141,7 +2141,7 @@
         },
         "name": "Scyther",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 124,
@@ -2159,7 +2159,7 @@
         },
         "name": "Jynx",
         "color": "Red",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 125,
@@ -2176,7 +2176,7 @@
         },
         "name": "Electabuzz",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 126,
@@ -2193,7 +2193,7 @@
         },
         "name": "Magmar",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 127,
@@ -2210,7 +2210,7 @@
         },
         "name": "Pinsir",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 128,
@@ -2227,7 +2227,7 @@
         },
         "name": "Tauros",
         "color": "Brown",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 129,
@@ -2244,7 +2244,7 @@
         },
         "name": "Magikarp",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 130,
@@ -2262,7 +2262,7 @@
         },
         "name": "Gyarados",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 131,
@@ -2280,7 +2280,7 @@
         },
         "name": "Lapras",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 132,
@@ -2297,7 +2297,7 @@
         },
         "name": "Ditto",
         "color": "Purple",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 133,
@@ -2314,7 +2314,7 @@
         },
         "name": "Eevee",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 134,
@@ -2331,7 +2331,7 @@
         },
         "name": "Vaporeon",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 135,
@@ -2348,7 +2348,7 @@
         },
         "name": "Jolteon",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 136,
@@ -2365,7 +2365,7 @@
         },
         "name": "Flareon",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 137,
@@ -2382,7 +2382,7 @@
         },
         "name": "Porygon",
         "color": "Pink",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 138,
@@ -2400,7 +2400,7 @@
         },
         "name": "Omanyte",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 139,
@@ -2418,7 +2418,7 @@
         },
         "name": "Omastar",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 140,
@@ -2436,7 +2436,7 @@
         },
         "name": "Kabuto",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 141,
@@ -2454,7 +2454,7 @@
         },
         "name": "Kabutops",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 142,
@@ -2472,7 +2472,7 @@
         },
         "name": "Aerodactyl",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 143,
@@ -2489,7 +2489,7 @@
         },
         "name": "Snorlax",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 144,
@@ -2507,7 +2507,7 @@
         },
         "name": "Articuno",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 145,
@@ -2525,7 +2525,7 @@
         },
         "name": "Zapdos",
         "color": "Yellow",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 146,
@@ -2543,7 +2543,7 @@
         },
         "name": "Moltres",
         "color": "Yellow",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 147,
@@ -2560,7 +2560,7 @@
         },
         "name": "Dratini",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 148,
@@ -2577,7 +2577,7 @@
         },
         "name": "Dragonair",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 149,
@@ -2595,7 +2595,7 @@
         },
         "name": "Dragonite",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 150,
@@ -2612,7 +2612,7 @@
         },
         "name": "Mewtwo",
         "color": "Purple",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 151,
@@ -2629,7 +2629,7 @@
         },
         "name": "Mew",
         "color": "Pink",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 152,
@@ -2646,7 +2646,7 @@
         },
         "name": "Chikorita",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 153,
@@ -2663,7 +2663,7 @@
         },
         "name": "Bayleef",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 154,
@@ -2680,7 +2680,7 @@
         },
         "name": "Meganium",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 155,
@@ -2697,7 +2697,7 @@
         },
         "name": "Cyndaquil",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 156,
@@ -2714,7 +2714,7 @@
         },
         "name": "Quilava",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 157,
@@ -2731,7 +2731,7 @@
         },
         "name": "Typhlosion",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 158,
@@ -2748,7 +2748,7 @@
         },
         "name": "Totodile",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 159,
@@ -2765,7 +2765,7 @@
         },
         "name": "Croconaw",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 160,
@@ -2782,7 +2782,7 @@
         },
         "name": "Feraligatr",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 161,
@@ -2799,7 +2799,7 @@
         },
         "name": "Sentret",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 162,
@@ -2816,7 +2816,7 @@
         },
         "name": "Furret",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 163,
@@ -2834,7 +2834,7 @@
         },
         "name": "Hoothoot",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 164,
@@ -2852,7 +2852,7 @@
         },
         "name": "Noctowl",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 165,
@@ -2870,7 +2870,7 @@
         },
         "name": "Ledyba",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 166,
@@ -2888,7 +2888,7 @@
         },
         "name": "Ledian",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 167,
@@ -2906,7 +2906,7 @@
         },
         "name": "Spinarak",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 168,
@@ -2924,7 +2924,7 @@
         },
         "name": "Ariados",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 169,
@@ -2942,7 +2942,7 @@
         },
         "name": "Crobat",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 170,
@@ -2960,7 +2960,7 @@
         },
         "name": "Chinchou",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 171,
@@ -2978,7 +2978,7 @@
         },
         "name": "Lanturn",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 172,
@@ -2995,7 +2995,7 @@
         },
         "name": "Pichu",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 173,
@@ -3012,7 +3012,7 @@
         },
         "name": "Cleffa",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 174,
@@ -3029,7 +3029,7 @@
         },
         "name": "Igglybuff",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 175,
@@ -3046,7 +3046,7 @@
         },
         "name": "Togepi",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 176,
@@ -3064,7 +3064,7 @@
         },
         "name": "Togetic",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 177,
@@ -3082,7 +3082,7 @@
         },
         "name": "Natu",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 178,
@@ -3100,7 +3100,7 @@
         },
         "name": "Xatu",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 179,
@@ -3117,7 +3117,7 @@
         },
         "name": "Mareep",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 180,
@@ -3134,7 +3134,7 @@
         },
         "name": "Flaaffy",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 181,
@@ -3151,7 +3151,7 @@
         },
         "name": "Ampharos",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 182,
@@ -3168,7 +3168,7 @@
         },
         "name": "Bellossom",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 183,
@@ -3185,7 +3185,7 @@
         },
         "name": "Marill",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 184,
@@ -3202,7 +3202,7 @@
         },
         "name": "Azumarill",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 185,
@@ -3219,7 +3219,7 @@
         },
         "name": "Sudowoodo",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 186,
@@ -3236,7 +3236,7 @@
         },
         "name": "Politoed",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 187,
@@ -3254,7 +3254,7 @@
         },
         "name": "Hoppip",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 188,
@@ -3272,7 +3272,7 @@
         },
         "name": "Skiploom",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 189,
@@ -3290,7 +3290,7 @@
         },
         "name": "Jumpluff",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 190,
@@ -3307,7 +3307,7 @@
         },
         "name": "Aipom",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 191,
@@ -3324,7 +3324,7 @@
         },
         "name": "Sunkern",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 192,
@@ -3341,7 +3341,7 @@
         },
         "name": "Sunflora",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 193,
@@ -3359,7 +3359,7 @@
         },
         "name": "Yanma",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 194,
@@ -3377,7 +3377,7 @@
         },
         "name": "Wooper",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 195,
@@ -3395,7 +3395,7 @@
         },
         "name": "Quagsire",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 196,
@@ -3412,7 +3412,7 @@
         },
         "name": "Espeon",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 197,
@@ -3429,7 +3429,7 @@
         },
         "name": "Umbreon",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 198,
@@ -3447,7 +3447,7 @@
         },
         "name": "Murkrow",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 199,
@@ -3465,7 +3465,7 @@
         },
         "name": "Slowking",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 200,
@@ -3482,7 +3482,7 @@
         },
         "name": "Misdreavus",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 201,
@@ -3499,7 +3499,7 @@
         },
         "name": "Unown",
         "color": "Black",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 202,
@@ -3516,7 +3516,7 @@
         },
         "name": "Wobbuffet",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 203,
@@ -3534,7 +3534,7 @@
         },
         "name": "Girafarig",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 204,
@@ -3551,7 +3551,7 @@
         },
         "name": "Pineco",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 205,
@@ -3569,7 +3569,7 @@
         },
         "name": "Forretress",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 206,
@@ -3586,7 +3586,7 @@
         },
         "name": "Dunsparce",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 207,
@@ -3604,7 +3604,7 @@
         },
         "name": "Gligar",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 208,
@@ -3622,7 +3622,7 @@
         },
         "name": "Steelix",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 209,
@@ -3639,7 +3639,7 @@
         },
         "name": "Snubbull",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 210,
@@ -3656,7 +3656,7 @@
         },
         "name": "Granbull",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 211,
@@ -3674,7 +3674,7 @@
         },
         "name": "Qwilfish",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 212,
@@ -3692,7 +3692,7 @@
         },
         "name": "Scizor",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 213,
@@ -3710,7 +3710,7 @@
         },
         "name": "Shuckle",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 214,
@@ -3728,7 +3728,7 @@
         },
         "name": "Heracross",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 215,
@@ -3746,7 +3746,7 @@
         },
         "name": "Sneasel",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 216,
@@ -3763,7 +3763,7 @@
         },
         "name": "Teddiursa",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 217,
@@ -3780,7 +3780,7 @@
         },
         "name": "Ursaring",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 218,
@@ -3797,7 +3797,7 @@
         },
         "name": "Slugma",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 219,
@@ -3815,7 +3815,7 @@
         },
         "name": "Magcargo",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 220,
@@ -3833,7 +3833,7 @@
         },
         "name": "Swinub",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 221,
@@ -3851,7 +3851,7 @@
         },
         "name": "Piloswine",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 222,
@@ -3869,7 +3869,7 @@
         },
         "name": "Corsola",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 223,
@@ -3886,7 +3886,7 @@
         },
         "name": "Remoraid",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 224,
@@ -3903,7 +3903,7 @@
         },
         "name": "Octillery",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 225,
@@ -3921,7 +3921,7 @@
         },
         "name": "Delibird",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 226,
@@ -3939,7 +3939,7 @@
         },
         "name": "Mantine",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 227,
@@ -3957,7 +3957,7 @@
         },
         "name": "Skarmory",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 228,
@@ -3975,7 +3975,7 @@
         },
         "name": "Houndour",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 229,
@@ -3993,7 +3993,7 @@
         },
         "name": "Houndoom",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 230,
@@ -4011,7 +4011,7 @@
         },
         "name": "Kingdra",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 231,
@@ -4028,7 +4028,7 @@
         },
         "name": "Phanpy",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 232,
@@ -4045,7 +4045,7 @@
         },
         "name": "Donphan",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 233,
@@ -4062,7 +4062,7 @@
         },
         "name": "Porygon2",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 234,
@@ -4079,7 +4079,7 @@
         },
         "name": "Stantler",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 235,
@@ -4096,7 +4096,7 @@
         },
         "name": "Smeargle",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 236,
@@ -4113,7 +4113,7 @@
         },
         "name": "Tyrogue",
         "color": "Purple",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 237,
@@ -4130,7 +4130,7 @@
         },
         "name": "Hitmontop",
         "color": "Brown",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 238,
@@ -4148,7 +4148,7 @@
         },
         "name": "Smoochum",
         "color": "Pink",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 239,
@@ -4165,7 +4165,7 @@
         },
         "name": "Elekid",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 240,
@@ -4182,7 +4182,7 @@
         },
         "name": "Magby",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 241,
@@ -4199,7 +4199,7 @@
         },
         "name": "Miltank",
         "color": "Pink",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 242,
@@ -4216,7 +4216,7 @@
         },
         "name": "Blissey",
         "color": "Pink",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 243,
@@ -4233,7 +4233,7 @@
         },
         "name": "Raikou",
         "color": "Yellow",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 244,
@@ -4250,7 +4250,7 @@
         },
         "name": "Entei",
         "color": "Brown",
-        "gender":  null
+        "genders": [null]
     },
     {
         "id": 245,
@@ -4267,7 +4267,7 @@
         },
         "name": "Suicune",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 246,
@@ -4285,7 +4285,7 @@
         },
         "name": "Larvitar",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 247,
@@ -4303,7 +4303,7 @@
         },
         "name": "Pupitar",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 248,
@@ -4321,7 +4321,7 @@
         },
         "name": "Tyranitar",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 249,
@@ -4339,7 +4339,7 @@
         },
         "name": "Lugia",
         "color": "White",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 250,
@@ -4357,7 +4357,7 @@
         },
         "name": "Ho-Oh",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 251,
@@ -4375,7 +4375,7 @@
         },
         "name": "Celebi",
         "color": "Green",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 252,
@@ -4392,7 +4392,7 @@
         },
         "name": "Treecko",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 253,
@@ -4409,7 +4409,7 @@
         },
         "name": "Grovyle",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 254,
@@ -4426,7 +4426,7 @@
         },
         "name": "Sceptile",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 255,
@@ -4443,7 +4443,7 @@
         },
         "name": "Torchic",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 256,
@@ -4461,7 +4461,7 @@
         },
         "name": "Combusken",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 257,
@@ -4479,7 +4479,7 @@
         },
         "name": "Blaziken",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 258,
@@ -4496,7 +4496,7 @@
         },
         "name": "Mudkip",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 259,
@@ -4514,7 +4514,7 @@
         },
         "name": "Marshtomp",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 260,
@@ -4532,7 +4532,7 @@
         },
         "name": "Swampert",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 261,
@@ -4549,7 +4549,7 @@
         },
         "name": "Poochyena",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 262,
@@ -4566,7 +4566,7 @@
         },
         "name": "Mightyena",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 263,
@@ -4583,7 +4583,7 @@
         },
         "name": "Zigzagoon",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 264,
@@ -4600,7 +4600,7 @@
         },
         "name": "Linoone",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 265,
@@ -4617,7 +4617,7 @@
         },
         "name": "Wurmple",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 266,
@@ -4634,7 +4634,7 @@
         },
         "name": "Silcoon",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 267,
@@ -4652,7 +4652,7 @@
         },
         "name": "Beautifly",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 268,
@@ -4669,7 +4669,7 @@
         },
         "name": "Cascoon",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 269,
@@ -4687,7 +4687,7 @@
         },
         "name": "Dustox",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 270,
@@ -4705,7 +4705,7 @@
         },
         "name": "Lotad",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 271,
@@ -4723,7 +4723,7 @@
         },
         "name": "Lombre",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 272,
@@ -4741,7 +4741,7 @@
         },
         "name": "Ludicolo",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 273,
@@ -4758,7 +4758,7 @@
         },
         "name": "Seedot",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 274,
@@ -4776,7 +4776,7 @@
         },
         "name": "Nuzleaf",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 275,
@@ -4794,7 +4794,7 @@
         },
         "name": "Shiftry",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 276,
@@ -4812,7 +4812,7 @@
         },
         "name": "Taillow",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 277,
@@ -4830,7 +4830,7 @@
         },
         "name": "Swellow",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 278,
@@ -4848,7 +4848,7 @@
         },
         "name": "Wingull",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 279,
@@ -4866,7 +4866,7 @@
         },
         "name": "Pelipper",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 280,
@@ -4883,7 +4883,7 @@
         },
         "name": "Ralts",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 281,
@@ -4900,7 +4900,7 @@
         },
         "name": "Kirlia",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 282,
@@ -4917,7 +4917,7 @@
         },
         "name": "Gardevoir",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 283,
@@ -4935,7 +4935,7 @@
         },
         "name": "Surskit",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 284,
@@ -4953,7 +4953,7 @@
         },
         "name": "Masquerain",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 285,
@@ -4970,7 +4970,7 @@
         },
         "name": "Shroomish",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 286,
@@ -4988,7 +4988,7 @@
         },
         "name": "Breloom",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 287,
@@ -5005,7 +5005,7 @@
         },
         "name": "Slakoth",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 288,
@@ -5022,7 +5022,7 @@
         },
         "name": "Vigoroth",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 289,
@@ -5039,7 +5039,7 @@
         },
         "name": "Slaking",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 290,
@@ -5057,7 +5057,7 @@
         },
         "name": "Nincada",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 291,
@@ -5075,7 +5075,7 @@
         },
         "name": "Ninjask",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 292,
@@ -5093,7 +5093,7 @@
         },
         "name": "Shedinja",
         "color": "Brown",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 293,
@@ -5110,7 +5110,7 @@
         },
         "name": "Whismur",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 294,
@@ -5127,7 +5127,7 @@
         },
         "name": "Loudred",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 295,
@@ -5144,7 +5144,7 @@
         },
         "name": "Exploud",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 296,
@@ -5161,7 +5161,7 @@
         },
         "name": "Makuhita",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 297,
@@ -5178,7 +5178,7 @@
         },
         "name": "Hariyama",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 298,
@@ -5195,7 +5195,7 @@
         },
         "name": "Azurill",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 299,
@@ -5212,7 +5212,7 @@
         },
         "name": "Nosepass",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 300,
@@ -5229,7 +5229,7 @@
         },
         "name": "Skitty",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 301,
@@ -5246,7 +5246,7 @@
         },
         "name": "Delcatty",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 302,
@@ -5264,7 +5264,7 @@
         },
         "name": "Sableye",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 303,
@@ -5281,7 +5281,7 @@
         },
         "name": "Mawile",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 304,
@@ -5299,7 +5299,7 @@
         },
         "name": "Aron",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 305,
@@ -5317,7 +5317,7 @@
         },
         "name": "Lairon",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 306,
@@ -5335,7 +5335,7 @@
         },
         "name": "Aggron",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 307,
@@ -5353,7 +5353,7 @@
         },
         "name": "Meditite",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 308,
@@ -5371,7 +5371,7 @@
         },
         "name": "Medicham",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 309,
@@ -5388,7 +5388,7 @@
         },
         "name": "Electrike",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 310,
@@ -5405,7 +5405,7 @@
         },
         "name": "Manectric",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 311,
@@ -5422,7 +5422,7 @@
         },
         "name": "Plusle",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 312,
@@ -5439,7 +5439,7 @@
         },
         "name": "Minun",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 313,
@@ -5456,7 +5456,7 @@
         },
         "name": "Volbeat",
         "color": "Gray",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 314,
@@ -5473,7 +5473,7 @@
         },
         "name": "Illumise",
         "color": "Purple",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 315,
@@ -5491,7 +5491,7 @@
         },
         "name": "Roselia",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 316,
@@ -5508,7 +5508,7 @@
         },
         "name": "Gulpin",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 317,
@@ -5525,7 +5525,7 @@
         },
         "name": "Swalot",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 318,
@@ -5543,7 +5543,7 @@
         },
         "name": "Carvanha",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 319,
@@ -5561,7 +5561,7 @@
         },
         "name": "Sharpedo",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 320,
@@ -5578,7 +5578,7 @@
         },
         "name": "Wailmer",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 321,
@@ -5595,7 +5595,7 @@
         },
         "name": "Wailord",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 322,
@@ -5613,7 +5613,7 @@
         },
         "name": "Numel",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 323,
@@ -5631,7 +5631,7 @@
         },
         "name": "Camerupt",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 324,
@@ -5648,7 +5648,7 @@
         },
         "name": "Torkoal",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 325,
@@ -5665,7 +5665,7 @@
         },
         "name": "Spoink",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 326,
@@ -5682,7 +5682,7 @@
         },
         "name": "Grumpig",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 327,
@@ -5699,7 +5699,7 @@
         },
         "name": "Spinda",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 328,
@@ -5716,7 +5716,7 @@
         },
         "name": "Trapinch",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 329,
@@ -5734,7 +5734,7 @@
         },
         "name": "Vibrava",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 330,
@@ -5752,7 +5752,7 @@
         },
         "name": "Flygon",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 331,
@@ -5769,7 +5769,7 @@
         },
         "name": "Cacnea",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 332,
@@ -5787,7 +5787,7 @@
         },
         "name": "Cacturne",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 333,
@@ -5805,7 +5805,7 @@
         },
         "name": "Swablu",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 334,
@@ -5823,7 +5823,7 @@
         },
         "name": "Altaria",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 335,
@@ -5840,7 +5840,7 @@
         },
         "name": "Zangoose",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 336,
@@ -5857,7 +5857,7 @@
         },
         "name": "Seviper",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 337,
@@ -5875,7 +5875,7 @@
         },
         "name": "Lunatone",
         "color": "Yellow",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 338,
@@ -5893,7 +5893,7 @@
         },
         "name": "Solrock",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 339,
@@ -5911,7 +5911,7 @@
         },
         "name": "Barboach",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 340,
@@ -5929,7 +5929,7 @@
         },
         "name": "Whiscash",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 341,
@@ -5946,7 +5946,7 @@
         },
         "name": "Corphish",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 342,
@@ -5964,7 +5964,7 @@
         },
         "name": "Crawdaunt",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 343,
@@ -5982,7 +5982,7 @@
         },
         "name": "Baltoy",
         "color": "Brown",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 344,
@@ -6000,7 +6000,7 @@
         },
         "name": "Claydol",
         "color": "Black",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 345,
@@ -6018,7 +6018,7 @@
         },
         "name": "Lileep",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 346,
@@ -6036,7 +6036,7 @@
         },
         "name": "Cradily",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 347,
@@ -6054,7 +6054,7 @@
         },
         "name": "Anorith",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 348,
@@ -6072,7 +6072,7 @@
         },
         "name": "Armaldo",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 349,
@@ -6089,7 +6089,7 @@
         },
         "name": "Feebas",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 350,
@@ -6106,7 +6106,7 @@
         },
         "name": "Milotic",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 351,
@@ -6123,7 +6123,7 @@
         },
         "name": "Castform",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 352,
@@ -6140,7 +6140,7 @@
         },
         "name": "Kecleon",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 353,
@@ -6157,7 +6157,7 @@
         },
         "name": "Shuppet",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 354,
@@ -6174,7 +6174,7 @@
         },
         "name": "Banette",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 355,
@@ -6191,7 +6191,7 @@
         },
         "name": "Duskull",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 356,
@@ -6208,7 +6208,7 @@
         },
         "name": "Dusclops",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 357,
@@ -6226,7 +6226,7 @@
         },
         "name": "Tropius",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 358,
@@ -6243,7 +6243,7 @@
         },
         "name": "Chimecho",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 359,
@@ -6260,7 +6260,7 @@
         },
         "name": "Absol",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 360,
@@ -6277,7 +6277,7 @@
         },
         "name": "Wynaut",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 361,
@@ -6294,7 +6294,7 @@
         },
         "name": "Snorunt",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 362,
@@ -6311,7 +6311,7 @@
         },
         "name": "Glalie",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 363,
@@ -6329,7 +6329,7 @@
         },
         "name": "Spheal",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 364,
@@ -6347,7 +6347,7 @@
         },
         "name": "Sealeo",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 365,
@@ -6365,7 +6365,7 @@
         },
         "name": "Walrein",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 366,
@@ -6382,7 +6382,7 @@
         },
         "name": "Clamperl",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 367,
@@ -6399,7 +6399,7 @@
         },
         "name": "Huntail",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 368,
@@ -6416,7 +6416,7 @@
         },
         "name": "Gorebyss",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 369,
@@ -6434,7 +6434,7 @@
         },
         "name": "Relicanth",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 370,
@@ -6451,7 +6451,7 @@
         },
         "name": "Luvdisc",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 371,
@@ -6468,7 +6468,7 @@
         },
         "name": "Bagon",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 372,
@@ -6485,7 +6485,7 @@
         },
         "name": "Shelgon",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 373,
@@ -6503,7 +6503,7 @@
         },
         "name": "Salamence",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 374,
@@ -6521,7 +6521,7 @@
         },
         "name": "Beldum",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 375,
@@ -6539,7 +6539,7 @@
         },
         "name": "Metang",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 376,
@@ -6557,7 +6557,7 @@
         },
         "name": "Metagross",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 377,
@@ -6574,7 +6574,7 @@
         },
         "name": "Regirock",
         "color": "Brown",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 378,
@@ -6591,7 +6591,7 @@
         },
         "name": "Regice",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 379,
@@ -6608,7 +6608,7 @@
         },
         "name": "Registeel",
         "color": "Gray",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 380,
@@ -6626,7 +6626,7 @@
         },
         "name": "Latias",
         "color": "Red",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 381,
@@ -6644,7 +6644,7 @@
         },
         "name": "Latios",
         "color": "Blue",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 382,
@@ -6661,7 +6661,7 @@
         },
         "name": "Kyogre",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 383,
@@ -6678,7 +6678,7 @@
         },
         "name": "Groudon",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 384,
@@ -6696,7 +6696,7 @@
         },
         "name": "Rayquaza",
         "color": "Green",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 385,
@@ -6714,7 +6714,7 @@
         },
         "name": "Jirachi",
         "color": "Yellow",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 386,
@@ -6731,7 +6731,7 @@
         },
         "name": "Deoxys",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 387,
@@ -6748,7 +6748,7 @@
         },
         "name": "Turtwig",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 388,
@@ -6765,7 +6765,7 @@
         },
         "name": "Grotle",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 389,
@@ -6783,7 +6783,7 @@
         },
         "name": "Torterra",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 390,
@@ -6800,7 +6800,7 @@
         },
         "name": "Chimchar",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 391,
@@ -6818,7 +6818,7 @@
         },
         "name": "Monferno",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 392,
@@ -6836,7 +6836,7 @@
         },
         "name": "Infernape",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 393,
@@ -6853,7 +6853,7 @@
         },
         "name": "Piplup",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 394,
@@ -6870,7 +6870,7 @@
         },
         "name": "Prinplup",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 395,
@@ -6888,7 +6888,7 @@
         },
         "name": "Empoleon",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 396,
@@ -6906,7 +6906,7 @@
         },
         "name": "Starly",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 397,
@@ -6924,7 +6924,7 @@
         },
         "name": "Staravia",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 398,
@@ -6942,7 +6942,7 @@
         },
         "name": "Staraptor",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 399,
@@ -6959,7 +6959,7 @@
         },
         "name": "Bidoof",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 400,
@@ -6977,7 +6977,7 @@
         },
         "name": "Bibarel",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 401,
@@ -6994,7 +6994,7 @@
         },
         "name": "Kricketot",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 402,
@@ -7011,7 +7011,7 @@
         },
         "name": "Kricketune",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 403,
@@ -7028,7 +7028,7 @@
         },
         "name": "Shinx",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 404,
@@ -7045,7 +7045,7 @@
         },
         "name": "Luxio",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 405,
@@ -7062,7 +7062,7 @@
         },
         "name": "Luxray",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 406,
@@ -7080,7 +7080,7 @@
         },
         "name": "Budew",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 407,
@@ -7098,7 +7098,7 @@
         },
         "name": "Roserade",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 408,
@@ -7115,7 +7115,7 @@
         },
         "name": "Cranidos",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 409,
@@ -7132,7 +7132,7 @@
         },
         "name": "Rampardos",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 410,
@@ -7150,7 +7150,7 @@
         },
         "name": "Shieldon",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 411,
@@ -7168,7 +7168,7 @@
         },
         "name": "Bastiodon",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 412,
@@ -7185,7 +7185,7 @@
         },
         "name": "Burmy",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 413,
@@ -7203,7 +7203,7 @@
         },
         "name": "Wormadam",
         "color": "Gray",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 414,
@@ -7221,7 +7221,7 @@
         },
         "name": "Mothim",
         "color": "Yellow",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 415,
@@ -7239,7 +7239,7 @@
         },
         "name": "Combee",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 416,
@@ -7257,7 +7257,7 @@
         },
         "name": "Vespiquen",
         "color": "Yellow",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 417,
@@ -7274,7 +7274,7 @@
         },
         "name": "Pachirisu",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 418,
@@ -7291,7 +7291,7 @@
         },
         "name": "Buizel",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 419,
@@ -7308,7 +7308,7 @@
         },
         "name": "Floatzel",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 420,
@@ -7325,7 +7325,7 @@
         },
         "name": "Cherubi",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 421,
@@ -7342,7 +7342,7 @@
         },
         "name": "Cherrim",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 422,
@@ -7359,7 +7359,7 @@
         },
         "name": "Shellos",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 423,
@@ -7377,7 +7377,7 @@
         },
         "name": "Gastrodon",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 424,
@@ -7394,7 +7394,7 @@
         },
         "name": "Ambipom",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 425,
@@ -7412,7 +7412,7 @@
         },
         "name": "Drifloon",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 426,
@@ -7430,7 +7430,7 @@
         },
         "name": "Drifblim",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 427,
@@ -7447,7 +7447,7 @@
         },
         "name": "Buneary",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 428,
@@ -7464,7 +7464,7 @@
         },
         "name": "Lopunny",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 429,
@@ -7481,7 +7481,7 @@
         },
         "name": "Mismagius",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 430,
@@ -7499,7 +7499,7 @@
         },
         "name": "Honchkrow",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 431,
@@ -7516,7 +7516,7 @@
         },
         "name": "Glameow",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 432,
@@ -7533,7 +7533,7 @@
         },
         "name": "Purugly",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 433,
@@ -7550,7 +7550,7 @@
         },
         "name": "Chingling",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 434,
@@ -7568,7 +7568,7 @@
         },
         "name": "Stunky",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 435,
@@ -7586,7 +7586,7 @@
         },
         "name": "Skuntank",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 436,
@@ -7604,7 +7604,7 @@
         },
         "name": "Bronzor",
         "color": "Green",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 437,
@@ -7622,7 +7622,7 @@
         },
         "name": "Bronzong",
         "color": "Green",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 438,
@@ -7639,7 +7639,7 @@
         },
         "name": "Bonsly",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 439,
@@ -7656,7 +7656,7 @@
         },
         "name": "Mime Jr.",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 440,
@@ -7673,7 +7673,7 @@
         },
         "name": "Happiny",
         "color": "Pink",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 441,
@@ -7691,7 +7691,7 @@
         },
         "name": "Chatot",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 442,
@@ -7709,7 +7709,7 @@
         },
         "name": "Spiritomb",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 443,
@@ -7727,7 +7727,7 @@
         },
         "name": "Gible",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 444,
@@ -7745,7 +7745,7 @@
         },
         "name": "Gabite",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 445,
@@ -7763,7 +7763,7 @@
         },
         "name": "Garchomp",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 446,
@@ -7780,7 +7780,7 @@
         },
         "name": "Munchlax",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 447,
@@ -7797,7 +7797,7 @@
         },
         "name": "Riolu",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 448,
@@ -7815,7 +7815,7 @@
         },
         "name": "Lucario",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 449,
@@ -7832,7 +7832,7 @@
         },
         "name": "Hippopotas",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 450,
@@ -7849,7 +7849,7 @@
         },
         "name": "Hippowdon",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 451,
@@ -7867,7 +7867,7 @@
         },
         "name": "Skorupi",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 452,
@@ -7885,7 +7885,7 @@
         },
         "name": "Drapion",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 453,
@@ -7903,7 +7903,7 @@
         },
         "name": "Croagunk",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 454,
@@ -7921,7 +7921,7 @@
         },
         "name": "Toxicroak",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 455,
@@ -7938,7 +7938,7 @@
         },
         "name": "Carnivine",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 456,
@@ -7955,7 +7955,7 @@
         },
         "name": "Finneon",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 457,
@@ -7972,7 +7972,7 @@
         },
         "name": "Lumineon",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 458,
@@ -7990,7 +7990,7 @@
         },
         "name": "Mantyke",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 459,
@@ -8008,7 +8008,7 @@
         },
         "name": "Snover",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 460,
@@ -8026,7 +8026,7 @@
         },
         "name": "Abomasnow",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 461,
@@ -8044,7 +8044,7 @@
         },
         "name": "Weavile",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 462,
@@ -8062,7 +8062,7 @@
         },
         "name": "Magnezone",
         "color": "Gray",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 463,
@@ -8079,7 +8079,7 @@
         },
         "name": "Lickilicky",
         "color": "Pink",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 464,
@@ -8097,7 +8097,7 @@
         },
         "name": "Rhyperior",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 465,
@@ -8114,7 +8114,7 @@
         },
         "name": "Tangrowth",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 466,
@@ -8131,7 +8131,7 @@
         },
         "name": "Electivire",
         "color": "Yellow",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 467,
@@ -8148,7 +8148,7 @@
         },
         "name": "Magmortar",
         "color": "Red",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 468,
@@ -8166,7 +8166,7 @@
         },
         "name": "Togekiss",
         "color": "White",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 469,
@@ -8184,7 +8184,7 @@
         },
         "name": "Yanmega",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 470,
@@ -8201,7 +8201,7 @@
         },
         "name": "Leafeon",
         "color": "Green",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 471,
@@ -8218,7 +8218,7 @@
         },
         "name": "Glaceon",
         "color": "Blue",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 472,
@@ -8236,7 +8236,7 @@
         },
         "name": "Gliscor",
         "color": "Purple",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 473,
@@ -8254,7 +8254,7 @@
         },
         "name": "Mamoswine",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 474,
@@ -8271,7 +8271,7 @@
         },
         "name": "Porygon-Z",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 475,
@@ -8289,7 +8289,7 @@
         },
         "name": "Gallade",
         "color": "White",
-        "gender": "m"
+        "genders": ["m"]
     },
     {
         "id": 476,
@@ -8307,7 +8307,7 @@
         },
         "name": "Probopass",
         "color": "Gray",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 477,
@@ -8324,7 +8324,7 @@
         },
         "name": "Dusknoir",
         "color": "Black",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 478,
@@ -8342,7 +8342,7 @@
         },
         "name": "Froslass",
         "color": "White",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 479,
@@ -8360,7 +8360,7 @@
         },
         "name": "Rotom",
         "color": "Red",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 480,
@@ -8377,7 +8377,7 @@
         },
         "name": "Uxie",
         "color": "Yellow",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 481,
@@ -8394,7 +8394,7 @@
         },
         "name": "Mesprit",
         "color": "Pink",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 482,
@@ -8411,7 +8411,7 @@
         },
         "name": "Azelf",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 483,
@@ -8429,7 +8429,7 @@
         },
         "name": "Dialga",
         "color": "White",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 484,
@@ -8447,7 +8447,7 @@
         },
         "name": "Palkia",
         "color": "Purple",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 485,
@@ -8465,7 +8465,7 @@
         },
         "name": "Heatran",
         "color": "Brown",
-        "gender": "mf"
+        "genders": ["m","f"]
     },
     {
         "id": 486,
@@ -8482,7 +8482,7 @@
         },
         "name": "Regigigas",
         "color": "White",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 487,
@@ -8500,7 +8500,7 @@
         },
         "name": "Giratina",
         "color": "Black",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 488,
@@ -8517,7 +8517,7 @@
         },
         "name": "Cresselia",
         "color": "Yellow",
-        "gender": "f"
+        "genders": ["f"]
     },
     {
         "id": 489,
@@ -8534,7 +8534,7 @@
         },
         "name": "Phione",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 490,
@@ -8551,7 +8551,7 @@
         },
         "name": "Manaphy",
         "color": "Blue",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 491,
@@ -8568,7 +8568,7 @@
         },
         "name": "Darkrai",
         "color": "Black",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 492,
@@ -8585,7 +8585,7 @@
         },
         "name": "Shaymin",
         "color": "Green",
-        "gender": null
+        "genders": [null]
     },
     {
         "id": 493,
@@ -8602,6 +8602,6 @@
         },
         "name": "Arceus",
         "color": "Gray",
-        "gender": null
+        "genders": [null]
     }
 ]

--- a/pokecat/gen4data/pokedex.json
+++ b/pokecat/gen4data/pokedex.json
@@ -15,7 +15,8 @@
             "spe": 45
         },
         "name": "Bulbasaur",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 2,
@@ -32,7 +33,8 @@
             "spe": 60
         },
         "name": "Ivysaur",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 3,
@@ -49,7 +51,8 @@
             "spe": 80
         },
         "name": "Venusaur",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 4,
@@ -65,7 +68,8 @@
             "spe": 65
         },
         "name": "Charmander",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 5,
@@ -81,7 +85,8 @@
             "spe": 80
         },
         "name": "Charmeleon",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 6,
@@ -98,7 +103,8 @@
             "spe": 100
         },
         "name": "Charizard",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 7,
@@ -114,7 +120,8 @@
             "spe": 43
         },
         "name": "Squirtle",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 8,
@@ -130,7 +137,8 @@
             "spe": 58
         },
         "name": "Wartortle",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 9,
@@ -146,7 +154,8 @@
             "spe": 78
         },
         "name": "Blastoise",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 10,
@@ -162,7 +171,8 @@
             "spe": 45
         },
         "name": "Caterpie",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 11,
@@ -178,7 +188,8 @@
             "spe": 30
         },
         "name": "Metapod",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 12,
@@ -195,7 +206,8 @@
             "spe": 70
         },
         "name": "Butterfree",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 13,
@@ -212,7 +224,8 @@
             "spe": 50
         },
         "name": "Weedle",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 14,
@@ -229,7 +242,8 @@
             "spe": 35
         },
         "name": "Kakuna",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 15,
@@ -246,7 +260,8 @@
             "spe": 75
         },
         "name": "Beedrill",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 16,
@@ -263,7 +278,8 @@
             "spe": 56
         },
         "name": "Pidgey",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 17,
@@ -280,7 +296,8 @@
             "spe": 71
         },
         "name": "Pidgeotto",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 18,
@@ -297,7 +314,8 @@
             "spe": 91
         },
         "name": "Pidgeot",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 19,
@@ -313,7 +331,8 @@
             "spe": 72
         },
         "name": "Rattata",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 20,
@@ -329,7 +348,8 @@
             "spe": 97
         },
         "name": "Raticate",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 21,
@@ -346,7 +366,8 @@
             "spe": 70
         },
         "name": "Spearow",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 22,
@@ -363,7 +384,8 @@
             "spe": 100
         },
         "name": "Fearow",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 23,
@@ -379,7 +401,8 @@
             "spe": 55
         },
         "name": "Ekans",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 24,
@@ -395,7 +418,8 @@
             "spe": 80
         },
         "name": "Arbok",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 25,
@@ -411,7 +435,8 @@
             "spe": 90
         },
         "name": "Pikachu",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 26,
@@ -427,7 +452,8 @@
             "spe": 100
         },
         "name": "Raichu",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 27,
@@ -443,7 +469,8 @@
             "spe": 40
         },
         "name": "Sandshrew",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 28,
@@ -459,7 +486,8 @@
             "spe": 65
         },
         "name": "Sandslash",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 29,
@@ -475,7 +503,8 @@
             "spe": 41
         },
         "name": "Nidoran\u2640",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "f"
     },
     {
         "id": 30,
@@ -491,7 +520,8 @@
             "spe": 56
         },
         "name": "Nidorina",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "f"
     },
     {
         "id": 31,
@@ -508,7 +538,8 @@
             "spe": 76
         },
         "name": "Nidoqueen",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "f"
     },
     {
         "id": 32,
@@ -524,7 +555,8 @@
             "spe": 50
         },
         "name": "Nidoran\u2642",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "m"
     },
     {
         "id": 33,
@@ -540,7 +572,8 @@
             "spe": 65
         },
         "name": "Nidorino",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "m"
     },
     {
         "id": 34,
@@ -557,7 +590,8 @@
             "spe": 85
         },
         "name": "Nidoking",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "m"
     },
     {
         "id": 35,
@@ -573,7 +607,8 @@
             "spe": 35
         },
         "name": "Clefairy",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 36,
@@ -589,7 +624,8 @@
             "spe": 60
         },
         "name": "Clefable",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 37,
@@ -605,7 +641,8 @@
             "spe": 65
         },
         "name": "Vulpix",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 38,
@@ -621,7 +658,8 @@
             "spe": 100
         },
         "name": "Ninetales",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 39,
@@ -637,7 +675,8 @@
             "spe": 20
         },
         "name": "Jigglypuff",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 40,
@@ -653,7 +692,8 @@
             "spe": 45
         },
         "name": "Wigglytuff",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 41,
@@ -670,7 +710,8 @@
             "spe": 55
         },
         "name": "Zubat",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 42,
@@ -687,7 +728,8 @@
             "spe": 90
         },
         "name": "Golbat",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 43,
@@ -704,7 +746,8 @@
             "spe": 30
         },
         "name": "Oddish",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 44,
@@ -721,7 +764,8 @@
             "spe": 40
         },
         "name": "Gloom",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 45,
@@ -738,7 +782,8 @@
             "spe": 50
         },
         "name": "Vileplume",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 46,
@@ -755,7 +800,8 @@
             "spe": 25
         },
         "name": "Paras",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 47,
@@ -772,7 +818,8 @@
             "spe": 30
         },
         "name": "Parasect",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 48,
@@ -789,7 +836,8 @@
             "spe": 45
         },
         "name": "Venonat",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 49,
@@ -806,7 +854,8 @@
             "spe": 90
         },
         "name": "Venomoth",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 50,
@@ -822,7 +871,8 @@
             "spe": 95
         },
         "name": "Diglett",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 51,
@@ -838,7 +888,8 @@
             "spe": 120
         },
         "name": "Dugtrio",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 52,
@@ -854,7 +905,8 @@
             "spe": 90
         },
         "name": "Meowth",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 53,
@@ -870,7 +922,8 @@
             "spe": 115
         },
         "name": "Persian",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 54,
@@ -886,7 +939,8 @@
             "spe": 55
         },
         "name": "Psyduck",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 55,
@@ -902,7 +956,8 @@
             "spe": 85
         },
         "name": "Golduck",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 56,
@@ -918,7 +973,8 @@
             "spe": 70
         },
         "name": "Mankey",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 57,
@@ -934,7 +990,8 @@
             "spe": 95
         },
         "name": "Primeape",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 58,
@@ -950,7 +1007,8 @@
             "spe": 60
         },
         "name": "Growlithe",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 59,
@@ -966,7 +1024,8 @@
             "spe": 95
         },
         "name": "Arcanine",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 60,
@@ -982,7 +1041,8 @@
             "spe": 90
         },
         "name": "Poliwag",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 61,
@@ -998,7 +1058,8 @@
             "spe": 90
         },
         "name": "Poliwhirl",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 62,
@@ -1015,7 +1076,8 @@
             "spe": 70
         },
         "name": "Poliwrath",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 63,
@@ -1031,7 +1093,8 @@
             "spe": 90
         },
         "name": "Abra",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 64,
@@ -1047,7 +1110,8 @@
             "spe": 105
         },
         "name": "Kadabra",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 65,
@@ -1063,7 +1127,8 @@
             "spe": 120
         },
         "name": "Alakazam",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 66,
@@ -1079,7 +1144,8 @@
             "spe": 35
         },
         "name": "Machop",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 67,
@@ -1095,7 +1161,8 @@
             "spe": 45
         },
         "name": "Machoke",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 68,
@@ -1111,7 +1178,8 @@
             "spe": 55
         },
         "name": "Machamp",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 69,
@@ -1128,7 +1196,8 @@
             "spe": 40
         },
         "name": "Bellsprout",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 70,
@@ -1145,7 +1214,8 @@
             "spe": 55
         },
         "name": "Weepinbell",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 71,
@@ -1162,7 +1232,8 @@
             "spe": 70
         },
         "name": "Victreebel",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 72,
@@ -1179,7 +1250,8 @@
             "spe": 70
         },
         "name": "Tentacool",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 73,
@@ -1196,7 +1268,8 @@
             "spe": 100
         },
         "name": "Tentacruel",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 74,
@@ -1213,7 +1286,8 @@
             "spe": 20
         },
         "name": "Geodude",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 75,
@@ -1230,7 +1304,8 @@
             "spe": 35
         },
         "name": "Graveler",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 76,
@@ -1247,7 +1322,8 @@
             "spe": 45
         },
         "name": "Golem",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 77,
@@ -1263,7 +1339,8 @@
             "spe": 90
         },
         "name": "Ponyta",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 78,
@@ -1279,7 +1356,8 @@
             "spe": 105
         },
         "name": "Rapidash",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 79,
@@ -1296,7 +1374,8 @@
             "spe": 15
         },
         "name": "Slowpoke",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 80,
@@ -1313,7 +1392,8 @@
             "spe": 30
         },
         "name": "Slowbro",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 81,
@@ -1330,7 +1410,8 @@
             "spe": 45
         },
         "name": "Magnemite",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": null
     },
     {
         "id": 82,
@@ -1347,7 +1428,8 @@
             "spe": 70
         },
         "name": "Magneton",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": null
     },
     {
         "id": 83,
@@ -1364,7 +1446,8 @@
             "spe": 60
         },
         "name": "Farfetch'd",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 84,
@@ -1381,7 +1464,8 @@
             "spe": 75
         },
         "name": "Doduo",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 85,
@@ -1398,7 +1482,8 @@
             "spe": 100
         },
         "name": "Dodrio",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 86,
@@ -1414,7 +1499,8 @@
             "spe": 45
         },
         "name": "Seel",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 87,
@@ -1431,7 +1517,8 @@
             "spe": 70
         },
         "name": "Dewgong",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 88,
@@ -1447,7 +1534,8 @@
             "spe": 25
         },
         "name": "Grimer",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 89,
@@ -1463,7 +1551,8 @@
             "spe": 50
         },
         "name": "Muk",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 90,
@@ -1479,7 +1568,8 @@
             "spe": 40
         },
         "name": "Shellder",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 91,
@@ -1496,7 +1586,8 @@
             "spe": 70
         },
         "name": "Cloyster",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 92,
@@ -1513,7 +1604,8 @@
             "spe": 80
         },
         "name": "Gastly",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 93,
@@ -1530,7 +1622,8 @@
             "spe": 95
         },
         "name": "Haunter",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 94,
@@ -1547,7 +1640,8 @@
             "spe": 110
         },
         "name": "Gengar",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 95,
@@ -1564,7 +1658,8 @@
             "spe": 70
         },
         "name": "Onix",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 96,
@@ -1580,7 +1675,8 @@
             "spe": 42
         },
         "name": "Drowzee",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 97,
@@ -1596,7 +1692,8 @@
             "spe": 67
         },
         "name": "Hypno",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 98,
@@ -1612,7 +1709,8 @@
             "spe": 50
         },
         "name": "Krabby",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 99,
@@ -1628,7 +1726,8 @@
             "spe": 75
         },
         "name": "Kingler",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 100,
@@ -1644,7 +1743,8 @@
             "spe": 100
         },
         "name": "Voltorb",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 101,
@@ -1660,7 +1760,8 @@
             "spe": 140
         },
         "name": "Electrode",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 102,
@@ -1677,7 +1778,8 @@
             "spe": 40
         },
         "name": "Exeggcute",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 103,
@@ -1694,7 +1796,8 @@
             "spe": 55
         },
         "name": "Exeggutor",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 104,
@@ -1710,7 +1813,8 @@
             "spe": 35
         },
         "name": "Cubone",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 105,
@@ -1726,7 +1830,8 @@
             "spe": 45
         },
         "name": "Marowak",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 106,
@@ -1742,7 +1847,8 @@
             "spe": 87
         },
         "name": "Hitmonlee",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "m"
     },
     {
         "id": 107,
@@ -1758,7 +1864,8 @@
             "spe": 76
         },
         "name": "Hitmonchan",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "m"
     },
     {
         "id": 108,
@@ -1774,7 +1881,8 @@
             "spe": 30
         },
         "name": "Lickitung",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 109,
@@ -1790,7 +1898,8 @@
             "spe": 35
         },
         "name": "Koffing",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 110,
@@ -1806,7 +1915,8 @@
             "spe": 60
         },
         "name": "Weezing",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 111,
@@ -1823,7 +1933,8 @@
             "spe": 25
         },
         "name": "Rhyhorn",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 112,
@@ -1840,7 +1951,8 @@
             "spe": 40
         },
         "name": "Rhydon",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 113,
@@ -1856,7 +1968,8 @@
             "spe": 50
         },
         "name": "Chansey",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "f"
     },
     {
         "id": 114,
@@ -1872,7 +1985,8 @@
             "spe": 60
         },
         "name": "Tangela",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 115,
@@ -1888,7 +2002,8 @@
             "spe": 90
         },
         "name": "Kangaskhan",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "f"
     },
     {
         "id": 116,
@@ -1904,7 +2019,8 @@
             "spe": 60
         },
         "name": "Horsea",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 117,
@@ -1920,7 +2036,8 @@
             "spe": 85
         },
         "name": "Seadra",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 118,
@@ -1936,7 +2053,8 @@
             "spe": 63
         },
         "name": "Goldeen",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 119,
@@ -1952,7 +2070,8 @@
             "spe": 68
         },
         "name": "Seaking",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 120,
@@ -1968,7 +2087,8 @@
             "spe": 85
         },
         "name": "Staryu",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": null
     },
     {
         "id": 121,
@@ -1985,7 +2105,8 @@
             "spe": 115
         },
         "name": "Starmie",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": null
     },
     {
         "id": 122,
@@ -2001,7 +2122,8 @@
             "spe": 90
         },
         "name": "Mr. Mime",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 123,
@@ -2018,7 +2140,8 @@
             "spe": 105
         },
         "name": "Scyther",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 124,
@@ -2035,7 +2158,8 @@
             "spe": 95
         },
         "name": "Jynx",
-        "color": "Red"
+        "color": "Red",
+        "gender": "f"
     },
     {
         "id": 125,
@@ -2051,7 +2175,8 @@
             "spe": 105
         },
         "name": "Electabuzz",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 126,
@@ -2067,7 +2192,8 @@
             "spe": 93
         },
         "name": "Magmar",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 127,
@@ -2083,7 +2209,8 @@
             "spe": 85
         },
         "name": "Pinsir",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 128,
@@ -2099,7 +2226,8 @@
             "spe": 110
         },
         "name": "Tauros",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "m"
     },
     {
         "id": 129,
@@ -2115,7 +2243,8 @@
             "spe": 80
         },
         "name": "Magikarp",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 130,
@@ -2132,7 +2261,8 @@
             "spe": 81
         },
         "name": "Gyarados",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 131,
@@ -2149,7 +2279,8 @@
             "spe": 60
         },
         "name": "Lapras",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 132,
@@ -2165,7 +2296,8 @@
             "spe": 48
         },
         "name": "Ditto",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": null
     },
     {
         "id": 133,
@@ -2181,7 +2313,8 @@
             "spe": 55
         },
         "name": "Eevee",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 134,
@@ -2197,7 +2330,8 @@
             "spe": 65
         },
         "name": "Vaporeon",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 135,
@@ -2213,7 +2347,8 @@
             "spe": 130
         },
         "name": "Jolteon",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 136,
@@ -2229,7 +2364,8 @@
             "spe": 65
         },
         "name": "Flareon",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 137,
@@ -2245,7 +2381,8 @@
             "spe": 40
         },
         "name": "Porygon",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": null
     },
     {
         "id": 138,
@@ -2262,7 +2399,8 @@
             "spe": 35
         },
         "name": "Omanyte",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 139,
@@ -2279,7 +2417,8 @@
             "spe": 55
         },
         "name": "Omastar",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 140,
@@ -2296,7 +2435,8 @@
             "spe": 55
         },
         "name": "Kabuto",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 141,
@@ -2313,7 +2453,8 @@
             "spe": 80
         },
         "name": "Kabutops",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 142,
@@ -2330,7 +2471,8 @@
             "spe": 130
         },
         "name": "Aerodactyl",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 143,
@@ -2346,7 +2488,8 @@
             "spe": 30
         },
         "name": "Snorlax",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 144,
@@ -2363,7 +2506,8 @@
             "spe": 85
         },
         "name": "Articuno",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 145,
@@ -2380,7 +2524,8 @@
             "spe": 100
         },
         "name": "Zapdos",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": null
     },
     {
         "id": 146,
@@ -2397,7 +2542,8 @@
             "spe": 90
         },
         "name": "Moltres",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": null
     },
     {
         "id": 147,
@@ -2413,7 +2559,8 @@
             "spe": 50
         },
         "name": "Dratini",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 148,
@@ -2429,7 +2576,8 @@
             "spe": 70
         },
         "name": "Dragonair",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 149,
@@ -2446,7 +2594,8 @@
             "spe": 80
         },
         "name": "Dragonite",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 150,
@@ -2462,7 +2611,8 @@
             "spe": 130
         },
         "name": "Mewtwo",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": null
     },
     {
         "id": 151,
@@ -2478,7 +2628,8 @@
             "spe": 100
         },
         "name": "Mew",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": null
     },
     {
         "id": 152,
@@ -2494,7 +2645,8 @@
             "spe": 45
         },
         "name": "Chikorita",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 153,
@@ -2510,7 +2662,8 @@
             "spe": 60
         },
         "name": "Bayleef",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 154,
@@ -2526,7 +2679,8 @@
             "spe": 80
         },
         "name": "Meganium",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 155,
@@ -2542,7 +2696,8 @@
             "spe": 65
         },
         "name": "Cyndaquil",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 156,
@@ -2558,7 +2713,8 @@
             "spe": 80
         },
         "name": "Quilava",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 157,
@@ -2574,7 +2730,8 @@
             "spe": 100
         },
         "name": "Typhlosion",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 158,
@@ -2590,7 +2747,8 @@
             "spe": 43
         },
         "name": "Totodile",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 159,
@@ -2606,7 +2764,8 @@
             "spe": 58
         },
         "name": "Croconaw",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 160,
@@ -2622,7 +2781,8 @@
             "spe": 78
         },
         "name": "Feraligatr",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 161,
@@ -2638,7 +2798,8 @@
             "spe": 20
         },
         "name": "Sentret",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 162,
@@ -2654,7 +2815,8 @@
             "spe": 90
         },
         "name": "Furret",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 163,
@@ -2671,7 +2833,8 @@
             "spe": 50
         },
         "name": "Hoothoot",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 164,
@@ -2688,7 +2851,8 @@
             "spe": 70
         },
         "name": "Noctowl",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 165,
@@ -2705,7 +2869,8 @@
             "spe": 55
         },
         "name": "Ledyba",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 166,
@@ -2722,7 +2887,8 @@
             "spe": 85
         },
         "name": "Ledian",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 167,
@@ -2739,7 +2905,8 @@
             "spe": 30
         },
         "name": "Spinarak",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 168,
@@ -2756,7 +2923,8 @@
             "spe": 40
         },
         "name": "Ariados",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 169,
@@ -2773,7 +2941,8 @@
             "spe": 130
         },
         "name": "Crobat",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 170,
@@ -2790,7 +2959,8 @@
             "spe": 67
         },
         "name": "Chinchou",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 171,
@@ -2807,7 +2977,8 @@
             "spe": 67
         },
         "name": "Lanturn",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 172,
@@ -2823,7 +2994,8 @@
             "spe": 60
         },
         "name": "Pichu",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 173,
@@ -2839,7 +3011,8 @@
             "spe": 15
         },
         "name": "Cleffa",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 174,
@@ -2855,7 +3028,8 @@
             "spe": 15
         },
         "name": "Igglybuff",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 175,
@@ -2871,7 +3045,8 @@
             "spe": 20
         },
         "name": "Togepi",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 176,
@@ -2888,7 +3063,8 @@
             "spe": 40
         },
         "name": "Togetic",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 177,
@@ -2905,7 +3081,8 @@
             "spe": 70
         },
         "name": "Natu",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 178,
@@ -2922,7 +3099,8 @@
             "spe": 95
         },
         "name": "Xatu",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 179,
@@ -2938,7 +3116,8 @@
             "spe": 35
         },
         "name": "Mareep",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 180,
@@ -2954,7 +3133,8 @@
             "spe": 45
         },
         "name": "Flaaffy",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 181,
@@ -2970,7 +3150,8 @@
             "spe": 55
         },
         "name": "Ampharos",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 182,
@@ -2986,7 +3167,8 @@
             "spe": 50
         },
         "name": "Bellossom",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 183,
@@ -3002,7 +3184,8 @@
             "spe": 40
         },
         "name": "Marill",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 184,
@@ -3018,7 +3201,8 @@
             "spe": 50
         },
         "name": "Azumarill",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 185,
@@ -3034,7 +3218,8 @@
             "spe": 30
         },
         "name": "Sudowoodo",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 186,
@@ -3050,7 +3235,8 @@
             "spe": 70
         },
         "name": "Politoed",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 187,
@@ -3067,7 +3253,8 @@
             "spe": 50
         },
         "name": "Hoppip",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 188,
@@ -3084,7 +3271,8 @@
             "spe": 80
         },
         "name": "Skiploom",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 189,
@@ -3101,7 +3289,8 @@
             "spe": 110
         },
         "name": "Jumpluff",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 190,
@@ -3117,7 +3306,8 @@
             "spe": 85
         },
         "name": "Aipom",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 191,
@@ -3133,7 +3323,8 @@
             "spe": 30
         },
         "name": "Sunkern",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 192,
@@ -3149,7 +3340,8 @@
             "spe": 30
         },
         "name": "Sunflora",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 193,
@@ -3166,7 +3358,8 @@
             "spe": 95
         },
         "name": "Yanma",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 194,
@@ -3183,7 +3376,8 @@
             "spe": 15
         },
         "name": "Wooper",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 195,
@@ -3200,7 +3394,8 @@
             "spe": 35
         },
         "name": "Quagsire",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 196,
@@ -3216,7 +3411,8 @@
             "spe": 110
         },
         "name": "Espeon",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 197,
@@ -3232,7 +3428,8 @@
             "spe": 65
         },
         "name": "Umbreon",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 198,
@@ -3249,7 +3446,8 @@
             "spe": 91
         },
         "name": "Murkrow",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 199,
@@ -3266,7 +3464,8 @@
             "spe": 30
         },
         "name": "Slowking",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 200,
@@ -3282,7 +3481,8 @@
             "spe": 85
         },
         "name": "Misdreavus",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 201,
@@ -3298,7 +3498,8 @@
             "spe": 48
         },
         "name": "Unown",
-        "color": "Black"
+        "color": "Black",
+        "gender": null
     },
     {
         "id": 202,
@@ -3314,7 +3515,8 @@
             "spe": 33
         },
         "name": "Wobbuffet",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 203,
@@ -3331,7 +3533,8 @@
             "spe": 85
         },
         "name": "Girafarig",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 204,
@@ -3347,7 +3550,8 @@
             "spe": 15
         },
         "name": "Pineco",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 205,
@@ -3364,7 +3568,8 @@
             "spe": 40
         },
         "name": "Forretress",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 206,
@@ -3380,7 +3585,8 @@
             "spe": 45
         },
         "name": "Dunsparce",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 207,
@@ -3397,7 +3603,8 @@
             "spe": 85
         },
         "name": "Gligar",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 208,
@@ -3414,7 +3621,8 @@
             "spe": 30
         },
         "name": "Steelix",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 209,
@@ -3430,7 +3638,8 @@
             "spe": 30
         },
         "name": "Snubbull",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 210,
@@ -3446,7 +3655,8 @@
             "spe": 45
         },
         "name": "Granbull",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 211,
@@ -3463,7 +3673,8 @@
             "spe": 85
         },
         "name": "Qwilfish",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 212,
@@ -3480,7 +3691,8 @@
             "spe": 65
         },
         "name": "Scizor",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 213,
@@ -3497,7 +3709,8 @@
             "spe": 5
         },
         "name": "Shuckle",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 214,
@@ -3514,7 +3727,8 @@
             "spe": 85
         },
         "name": "Heracross",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 215,
@@ -3531,7 +3745,8 @@
             "spe": 115
         },
         "name": "Sneasel",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 216,
@@ -3547,7 +3762,8 @@
             "spe": 40
         },
         "name": "Teddiursa",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 217,
@@ -3563,7 +3779,8 @@
             "spe": 55
         },
         "name": "Ursaring",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 218,
@@ -3579,7 +3796,8 @@
             "spe": 20
         },
         "name": "Slugma",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 219,
@@ -3596,7 +3814,8 @@
             "spe": 30
         },
         "name": "Magcargo",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 220,
@@ -3613,7 +3832,8 @@
             "spe": 50
         },
         "name": "Swinub",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 221,
@@ -3630,7 +3850,8 @@
             "spe": 50
         },
         "name": "Piloswine",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 222,
@@ -3647,7 +3868,8 @@
             "spe": 35
         },
         "name": "Corsola",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 223,
@@ -3663,7 +3885,8 @@
             "spe": 65
         },
         "name": "Remoraid",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 224,
@@ -3679,7 +3902,8 @@
             "spe": 45
         },
         "name": "Octillery",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 225,
@@ -3696,7 +3920,8 @@
             "spe": 75
         },
         "name": "Delibird",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 226,
@@ -3713,7 +3938,8 @@
             "spe": 70
         },
         "name": "Mantine",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 227,
@@ -3730,7 +3956,8 @@
             "spe": 70
         },
         "name": "Skarmory",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 228,
@@ -3747,7 +3974,8 @@
             "spe": 65
         },
         "name": "Houndour",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 229,
@@ -3764,7 +3992,8 @@
             "spe": 95
         },
         "name": "Houndoom",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 230,
@@ -3781,7 +4010,8 @@
             "spe": 85
         },
         "name": "Kingdra",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 231,
@@ -3797,7 +4027,8 @@
             "spe": 40
         },
         "name": "Phanpy",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 232,
@@ -3813,7 +4044,8 @@
             "spe": 50
         },
         "name": "Donphan",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 233,
@@ -3829,7 +4061,8 @@
             "spe": 60
         },
         "name": "Porygon2",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 234,
@@ -3845,7 +4078,8 @@
             "spe": 85
         },
         "name": "Stantler",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 235,
@@ -3861,7 +4095,8 @@
             "spe": 75
         },
         "name": "Smeargle",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 236,
@@ -3877,7 +4112,8 @@
             "spe": 35
         },
         "name": "Tyrogue",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "m"
     },
     {
         "id": 237,
@@ -3893,7 +4129,8 @@
             "spe": 70
         },
         "name": "Hitmontop",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "m"
     },
     {
         "id": 238,
@@ -3910,7 +4147,8 @@
             "spe": 65
         },
         "name": "Smoochum",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "f"
     },
     {
         "id": 239,
@@ -3926,7 +4164,8 @@
             "spe": 95
         },
         "name": "Elekid",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 240,
@@ -3942,7 +4181,8 @@
             "spe": 83
         },
         "name": "Magby",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 241,
@@ -3958,7 +4198,8 @@
             "spe": 100
         },
         "name": "Miltank",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "f"
     },
     {
         "id": 242,
@@ -3974,7 +4215,8 @@
             "spe": 55
         },
         "name": "Blissey",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "f"
     },
     {
         "id": 243,
@@ -3990,7 +4232,8 @@
             "spe": 115
         },
         "name": "Raikou",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": null
     },
     {
         "id": 244,
@@ -4006,7 +4249,8 @@
             "spe": 100
         },
         "name": "Entei",
-        "color": "Brown"
+        "color": "Brown",
+        "gender":  null
     },
     {
         "id": 245,
@@ -4022,7 +4266,8 @@
             "spe": 85
         },
         "name": "Suicune",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 246,
@@ -4039,7 +4284,8 @@
             "spe": 41
         },
         "name": "Larvitar",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 247,
@@ -4056,7 +4302,8 @@
             "spe": 51
         },
         "name": "Pupitar",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 248,
@@ -4073,7 +4320,8 @@
             "spe": 61
         },
         "name": "Tyranitar",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 249,
@@ -4090,7 +4338,8 @@
             "spe": 110
         },
         "name": "Lugia",
-        "color": "White"
+        "color": "White",
+        "gender": null
     },
     {
         "id": 250,
@@ -4107,7 +4356,8 @@
             "spe": 90
         },
         "name": "Ho-Oh",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 251,
@@ -4124,7 +4374,8 @@
             "spe": 100
         },
         "name": "Celebi",
-        "color": "Green"
+        "color": "Green",
+        "gender": null
     },
     {
         "id": 252,
@@ -4140,7 +4391,8 @@
             "spe": 70
         },
         "name": "Treecko",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 253,
@@ -4156,7 +4408,8 @@
             "spe": 95
         },
         "name": "Grovyle",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 254,
@@ -4172,7 +4425,8 @@
             "spe": 120
         },
         "name": "Sceptile",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 255,
@@ -4188,7 +4442,8 @@
             "spe": 45
         },
         "name": "Torchic",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 256,
@@ -4205,7 +4460,8 @@
             "spe": 55
         },
         "name": "Combusken",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 257,
@@ -4222,7 +4478,8 @@
             "spe": 80
         },
         "name": "Blaziken",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 258,
@@ -4238,7 +4495,8 @@
             "spe": 40
         },
         "name": "Mudkip",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 259,
@@ -4255,7 +4513,8 @@
             "spe": 50
         },
         "name": "Marshtomp",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 260,
@@ -4272,7 +4531,8 @@
             "spe": 60
         },
         "name": "Swampert",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 261,
@@ -4288,7 +4548,8 @@
             "spe": 35
         },
         "name": "Poochyena",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 262,
@@ -4304,7 +4565,8 @@
             "spe": 70
         },
         "name": "Mightyena",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 263,
@@ -4320,7 +4582,8 @@
             "spe": 60
         },
         "name": "Zigzagoon",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 264,
@@ -4336,7 +4599,8 @@
             "spe": 100
         },
         "name": "Linoone",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 265,
@@ -4352,7 +4616,8 @@
             "spe": 20
         },
         "name": "Wurmple",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 266,
@@ -4368,7 +4633,8 @@
             "spe": 15
         },
         "name": "Silcoon",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 267,
@@ -4385,7 +4651,8 @@
             "spe": 65
         },
         "name": "Beautifly",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 268,
@@ -4401,7 +4668,8 @@
             "spe": 15
         },
         "name": "Cascoon",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 269,
@@ -4418,7 +4686,8 @@
             "spe": 65
         },
         "name": "Dustox",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 270,
@@ -4435,7 +4704,8 @@
             "spe": 30
         },
         "name": "Lotad",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 271,
@@ -4452,7 +4722,8 @@
             "spe": 50
         },
         "name": "Lombre",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 272,
@@ -4469,7 +4740,8 @@
             "spe": 70
         },
         "name": "Ludicolo",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 273,
@@ -4485,7 +4757,8 @@
             "spe": 30
         },
         "name": "Seedot",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 274,
@@ -4502,7 +4775,8 @@
             "spe": 60
         },
         "name": "Nuzleaf",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 275,
@@ -4519,7 +4793,8 @@
             "spe": 80
         },
         "name": "Shiftry",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 276,
@@ -4536,7 +4811,8 @@
             "spe": 85
         },
         "name": "Taillow",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 277,
@@ -4553,7 +4829,8 @@
             "spe": 125
         },
         "name": "Swellow",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 278,
@@ -4570,7 +4847,8 @@
             "spe": 85
         },
         "name": "Wingull",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 279,
@@ -4587,7 +4865,8 @@
             "spe": 65
         },
         "name": "Pelipper",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 280,
@@ -4603,7 +4882,8 @@
             "spe": 40
         },
         "name": "Ralts",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 281,
@@ -4619,7 +4899,8 @@
             "spe": 50
         },
         "name": "Kirlia",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 282,
@@ -4635,7 +4916,8 @@
             "spe": 80
         },
         "name": "Gardevoir",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 283,
@@ -4652,7 +4934,8 @@
             "spe": 65
         },
         "name": "Surskit",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 284,
@@ -4669,7 +4952,8 @@
             "spe": 60
         },
         "name": "Masquerain",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 285,
@@ -4685,7 +4969,8 @@
             "spe": 35
         },
         "name": "Shroomish",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 286,
@@ -4702,7 +4987,8 @@
             "spe": 70
         },
         "name": "Breloom",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 287,
@@ -4718,7 +5004,8 @@
             "spe": 30
         },
         "name": "Slakoth",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 288,
@@ -4734,7 +5021,8 @@
             "spe": 90
         },
         "name": "Vigoroth",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 289,
@@ -4750,7 +5038,8 @@
             "spe": 100
         },
         "name": "Slaking",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 290,
@@ -4767,7 +5056,8 @@
             "spe": 40
         },
         "name": "Nincada",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 291,
@@ -4784,7 +5074,8 @@
             "spe": 160
         },
         "name": "Ninjask",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 292,
@@ -4801,7 +5092,8 @@
             "spe": 40
         },
         "name": "Shedinja",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": null
     },
     {
         "id": 293,
@@ -4817,7 +5109,8 @@
             "spe": 28
         },
         "name": "Whismur",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 294,
@@ -4833,7 +5126,8 @@
             "spe": 48
         },
         "name": "Loudred",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 295,
@@ -4849,7 +5143,8 @@
             "spe": 68
         },
         "name": "Exploud",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 296,
@@ -4865,7 +5160,8 @@
             "spe": 25
         },
         "name": "Makuhita",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 297,
@@ -4881,7 +5177,8 @@
             "spe": 50
         },
         "name": "Hariyama",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 298,
@@ -4897,7 +5194,8 @@
             "spe": 20
         },
         "name": "Azurill",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 299,
@@ -4913,7 +5211,8 @@
             "spe": 30
         },
         "name": "Nosepass",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 300,
@@ -4929,7 +5228,8 @@
             "spe": 50
         },
         "name": "Skitty",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 301,
@@ -4945,7 +5245,8 @@
             "spe": 70
         },
         "name": "Delcatty",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 302,
@@ -4962,7 +5263,8 @@
             "spe": 50
         },
         "name": "Sableye",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 303,
@@ -4978,7 +5280,8 @@
             "spe": 50
         },
         "name": "Mawile",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 304,
@@ -4995,7 +5298,8 @@
             "spe": 30
         },
         "name": "Aron",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 305,
@@ -5012,7 +5316,8 @@
             "spe": 40
         },
         "name": "Lairon",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 306,
@@ -5029,7 +5334,8 @@
             "spe": 50
         },
         "name": "Aggron",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 307,
@@ -5046,7 +5352,8 @@
             "spe": 60
         },
         "name": "Meditite",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 308,
@@ -5063,7 +5370,8 @@
             "spe": 80
         },
         "name": "Medicham",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 309,
@@ -5079,7 +5387,8 @@
             "spe": 65
         },
         "name": "Electrike",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 310,
@@ -5095,7 +5404,8 @@
             "spe": 105
         },
         "name": "Manectric",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 311,
@@ -5111,7 +5421,8 @@
             "spe": 95
         },
         "name": "Plusle",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 312,
@@ -5127,7 +5438,8 @@
             "spe": 95
         },
         "name": "Minun",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 313,
@@ -5143,7 +5455,8 @@
             "spe": 85
         },
         "name": "Volbeat",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "m"
     },
     {
         "id": 314,
@@ -5159,7 +5472,8 @@
             "spe": 85
         },
         "name": "Illumise",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "f"
     },
     {
         "id": 315,
@@ -5176,7 +5490,8 @@
             "spe": 65
         },
         "name": "Roselia",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 316,
@@ -5192,7 +5507,8 @@
             "spe": 40
         },
         "name": "Gulpin",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 317,
@@ -5208,7 +5524,8 @@
             "spe": 55
         },
         "name": "Swalot",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 318,
@@ -5225,7 +5542,8 @@
             "spe": 65
         },
         "name": "Carvanha",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 319,
@@ -5242,7 +5560,8 @@
             "spe": 95
         },
         "name": "Sharpedo",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 320,
@@ -5258,7 +5577,8 @@
             "spe": 60
         },
         "name": "Wailmer",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 321,
@@ -5274,7 +5594,8 @@
             "spe": 60
         },
         "name": "Wailord",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 322,
@@ -5291,7 +5612,8 @@
             "spe": 35
         },
         "name": "Numel",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 323,
@@ -5308,7 +5630,8 @@
             "spe": 40
         },
         "name": "Camerupt",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 324,
@@ -5324,7 +5647,8 @@
             "spe": 20
         },
         "name": "Torkoal",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 325,
@@ -5340,7 +5664,8 @@
             "spe": 60
         },
         "name": "Spoink",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 326,
@@ -5356,7 +5681,8 @@
             "spe": 80
         },
         "name": "Grumpig",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 327,
@@ -5372,7 +5698,8 @@
             "spe": 60
         },
         "name": "Spinda",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 328,
@@ -5388,7 +5715,8 @@
             "spe": 10
         },
         "name": "Trapinch",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 329,
@@ -5405,7 +5733,8 @@
             "spe": 70
         },
         "name": "Vibrava",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 330,
@@ -5422,7 +5751,8 @@
             "spe": 100
         },
         "name": "Flygon",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 331,
@@ -5438,7 +5768,8 @@
             "spe": 35
         },
         "name": "Cacnea",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 332,
@@ -5455,7 +5786,8 @@
             "spe": 55
         },
         "name": "Cacturne",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 333,
@@ -5472,7 +5804,8 @@
             "spe": 50
         },
         "name": "Swablu",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 334,
@@ -5489,7 +5822,8 @@
             "spe": 80
         },
         "name": "Altaria",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 335,
@@ -5505,7 +5839,8 @@
             "spe": 90
         },
         "name": "Zangoose",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 336,
@@ -5521,7 +5856,8 @@
             "spe": 65
         },
         "name": "Seviper",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 337,
@@ -5538,7 +5874,8 @@
             "spe": 70
         },
         "name": "Lunatone",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": null
     },
     {
         "id": 338,
@@ -5555,7 +5892,8 @@
             "spe": 70
         },
         "name": "Solrock",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 339,
@@ -5572,7 +5910,8 @@
             "spe": 60
         },
         "name": "Barboach",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 340,
@@ -5589,7 +5928,8 @@
             "spe": 60
         },
         "name": "Whiscash",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 341,
@@ -5605,7 +5945,8 @@
             "spe": 35
         },
         "name": "Corphish",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 342,
@@ -5622,7 +5963,8 @@
             "spe": 55
         },
         "name": "Crawdaunt",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 343,
@@ -5639,7 +5981,8 @@
             "spe": 55
         },
         "name": "Baltoy",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": null
     },
     {
         "id": 344,
@@ -5656,7 +5999,8 @@
             "spe": 75
         },
         "name": "Claydol",
-        "color": "Black"
+        "color": "Black",
+        "gender": null
     },
     {
         "id": 345,
@@ -5673,7 +6017,8 @@
             "spe": 23
         },
         "name": "Lileep",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 346,
@@ -5690,7 +6035,8 @@
             "spe": 43
         },
         "name": "Cradily",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 347,
@@ -5707,7 +6053,8 @@
             "spe": 75
         },
         "name": "Anorith",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 348,
@@ -5724,7 +6071,8 @@
             "spe": 45
         },
         "name": "Armaldo",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 349,
@@ -5740,7 +6088,8 @@
             "spe": 80
         },
         "name": "Feebas",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 350,
@@ -5756,7 +6105,8 @@
             "spe": 81
         },
         "name": "Milotic",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 351,
@@ -5772,7 +6122,8 @@
             "spe": 70
         },
         "name": "Castform",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 352,
@@ -5788,7 +6139,8 @@
             "spe": 40
         },
         "name": "Kecleon",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 353,
@@ -5804,7 +6156,8 @@
             "spe": 45
         },
         "name": "Shuppet",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 354,
@@ -5820,7 +6173,8 @@
             "spe": 65
         },
         "name": "Banette",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 355,
@@ -5836,7 +6190,8 @@
             "spe": 25
         },
         "name": "Duskull",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 356,
@@ -5852,7 +6207,8 @@
             "spe": 25
         },
         "name": "Dusclops",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 357,
@@ -5869,7 +6225,8 @@
             "spe": 51
         },
         "name": "Tropius",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 358,
@@ -5885,7 +6242,8 @@
             "spe": 65
         },
         "name": "Chimecho",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 359,
@@ -5901,7 +6259,8 @@
             "spe": 75
         },
         "name": "Absol",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 360,
@@ -5917,7 +6276,8 @@
             "spe": 23
         },
         "name": "Wynaut",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 361,
@@ -5933,7 +6293,8 @@
             "spe": 50
         },
         "name": "Snorunt",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 362,
@@ -5949,7 +6310,8 @@
             "spe": 80
         },
         "name": "Glalie",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 363,
@@ -5966,7 +6328,8 @@
             "spe": 25
         },
         "name": "Spheal",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 364,
@@ -5983,7 +6346,8 @@
             "spe": 45
         },
         "name": "Sealeo",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 365,
@@ -6000,7 +6364,8 @@
             "spe": 65
         },
         "name": "Walrein",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 366,
@@ -6016,7 +6381,8 @@
             "spe": 32
         },
         "name": "Clamperl",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 367,
@@ -6032,7 +6398,8 @@
             "spe": 52
         },
         "name": "Huntail",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 368,
@@ -6048,7 +6415,8 @@
             "spe": 52
         },
         "name": "Gorebyss",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 369,
@@ -6065,7 +6433,8 @@
             "spe": 55
         },
         "name": "Relicanth",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 370,
@@ -6081,7 +6450,8 @@
             "spe": 97
         },
         "name": "Luvdisc",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 371,
@@ -6097,7 +6467,8 @@
             "spe": 50
         },
         "name": "Bagon",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 372,
@@ -6113,7 +6484,8 @@
             "spe": 50
         },
         "name": "Shelgon",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 373,
@@ -6130,7 +6502,8 @@
             "spe": 100
         },
         "name": "Salamence",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 374,
@@ -6147,7 +6520,8 @@
             "spe": 30
         },
         "name": "Beldum",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 375,
@@ -6164,7 +6538,8 @@
             "spe": 50
         },
         "name": "Metang",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 376,
@@ -6181,7 +6556,8 @@
             "spe": 70
         },
         "name": "Metagross",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 377,
@@ -6197,7 +6573,8 @@
             "spe": 50
         },
         "name": "Regirock",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": null
     },
     {
         "id": 378,
@@ -6213,7 +6590,8 @@
             "spe": 50
         },
         "name": "Regice",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 379,
@@ -6229,7 +6607,8 @@
             "spe": 50
         },
         "name": "Registeel",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": null
     },
     {
         "id": 380,
@@ -6246,7 +6625,8 @@
             "spe": 110
         },
         "name": "Latias",
-        "color": "Red"
+        "color": "Red",
+        "gender": "f"
     },
     {
         "id": 381,
@@ -6263,7 +6643,8 @@
             "spe": 110
         },
         "name": "Latios",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "m"
     },
     {
         "id": 382,
@@ -6279,7 +6660,8 @@
             "spe": 90
         },
         "name": "Kyogre",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 383,
@@ -6295,7 +6677,8 @@
             "spe": 90
         },
         "name": "Groudon",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 384,
@@ -6312,7 +6695,8 @@
             "spe": 95
         },
         "name": "Rayquaza",
-        "color": "Green"
+        "color": "Green",
+        "gender": null
     },
     {
         "id": 385,
@@ -6329,7 +6713,8 @@
             "spe": 100
         },
         "name": "Jirachi",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": null
     },
     {
         "id": 386,
@@ -6345,7 +6730,8 @@
             "spe": 150
         },
         "name": "Deoxys",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 387,
@@ -6361,7 +6747,8 @@
             "spe": 31
         },
         "name": "Turtwig",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 388,
@@ -6377,7 +6764,8 @@
             "spe": 36
         },
         "name": "Grotle",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 389,
@@ -6394,7 +6782,8 @@
             "spe": 56
         },
         "name": "Torterra",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 390,
@@ -6410,7 +6799,8 @@
             "spe": 61
         },
         "name": "Chimchar",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 391,
@@ -6427,7 +6817,8 @@
             "spe": 81
         },
         "name": "Monferno",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 392,
@@ -6444,7 +6835,8 @@
             "spe": 108
         },
         "name": "Infernape",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 393,
@@ -6460,7 +6852,8 @@
             "spe": 40
         },
         "name": "Piplup",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 394,
@@ -6476,7 +6869,8 @@
             "spe": 50
         },
         "name": "Prinplup",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 395,
@@ -6493,7 +6887,8 @@
             "spe": 60
         },
         "name": "Empoleon",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 396,
@@ -6510,7 +6905,8 @@
             "spe": 60
         },
         "name": "Starly",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 397,
@@ -6527,7 +6923,8 @@
             "spe": 80
         },
         "name": "Staravia",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 398,
@@ -6544,7 +6941,8 @@
             "spe": 100
         },
         "name": "Staraptor",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 399,
@@ -6560,7 +6958,8 @@
             "spe": 31
         },
         "name": "Bidoof",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 400,
@@ -6577,7 +6976,8 @@
             "spe": 71
         },
         "name": "Bibarel",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 401,
@@ -6593,7 +6993,8 @@
             "spe": 25
         },
         "name": "Kricketot",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 402,
@@ -6609,7 +7010,8 @@
             "spe": 65
         },
         "name": "Kricketune",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 403,
@@ -6625,7 +7027,8 @@
             "spe": 45
         },
         "name": "Shinx",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 404,
@@ -6641,7 +7044,8 @@
             "spe": 60
         },
         "name": "Luxio",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 405,
@@ -6657,7 +7061,8 @@
             "spe": 70
         },
         "name": "Luxray",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 406,
@@ -6674,7 +7079,8 @@
             "spe": 55
         },
         "name": "Budew",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 407,
@@ -6691,7 +7097,8 @@
             "spe": 90
         },
         "name": "Roserade",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 408,
@@ -6707,7 +7114,8 @@
             "spe": 58
         },
         "name": "Cranidos",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 409,
@@ -6723,7 +7131,8 @@
             "spe": 58
         },
         "name": "Rampardos",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 410,
@@ -6740,7 +7149,8 @@
             "spe": 30
         },
         "name": "Shieldon",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 411,
@@ -6757,7 +7167,8 @@
             "spe": 30
         },
         "name": "Bastiodon",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 412,
@@ -6773,7 +7184,8 @@
             "spe": 36
         },
         "name": "Burmy",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 413,
@@ -6790,7 +7202,8 @@
             "spe": 36
         },
         "name": "Wormadam",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "f"
     },
     {
         "id": 414,
@@ -6807,7 +7220,8 @@
             "spe": 66
         },
         "name": "Mothim",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "m"
     },
     {
         "id": 415,
@@ -6824,7 +7238,8 @@
             "spe": 70
         },
         "name": "Combee",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 416,
@@ -6841,7 +7256,8 @@
             "spe": 40
         },
         "name": "Vespiquen",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "f"
     },
     {
         "id": 417,
@@ -6857,7 +7273,8 @@
             "spe": 95
         },
         "name": "Pachirisu",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 418,
@@ -6873,7 +7290,8 @@
             "spe": 85
         },
         "name": "Buizel",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 419,
@@ -6889,7 +7307,8 @@
             "spe": 115
         },
         "name": "Floatzel",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 420,
@@ -6905,7 +7324,8 @@
             "spe": 35
         },
         "name": "Cherubi",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 421,
@@ -6921,7 +7341,8 @@
             "spe": 85
         },
         "name": "Cherrim",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 422,
@@ -6937,7 +7358,8 @@
             "spe": 34
         },
         "name": "Shellos",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 423,
@@ -6954,7 +7376,8 @@
             "spe": 39
         },
         "name": "Gastrodon",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 424,
@@ -6970,7 +7393,8 @@
             "spe": 115
         },
         "name": "Ambipom",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 425,
@@ -6987,7 +7411,8 @@
             "spe": 70
         },
         "name": "Drifloon",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 426,
@@ -7004,7 +7429,8 @@
             "spe": 80
         },
         "name": "Drifblim",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 427,
@@ -7020,7 +7446,8 @@
             "spe": 85
         },
         "name": "Buneary",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 428,
@@ -7036,7 +7463,8 @@
             "spe": 105
         },
         "name": "Lopunny",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 429,
@@ -7052,7 +7480,8 @@
             "spe": 105
         },
         "name": "Mismagius",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 430,
@@ -7069,7 +7498,8 @@
             "spe": 71
         },
         "name": "Honchkrow",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 431,
@@ -7085,7 +7515,8 @@
             "spe": 85
         },
         "name": "Glameow",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 432,
@@ -7101,7 +7532,8 @@
             "spe": 112
         },
         "name": "Purugly",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 433,
@@ -7117,7 +7549,8 @@
             "spe": 45
         },
         "name": "Chingling",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 434,
@@ -7134,7 +7567,8 @@
             "spe": 74
         },
         "name": "Stunky",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 435,
@@ -7151,7 +7585,8 @@
             "spe": 84
         },
         "name": "Skuntank",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 436,
@@ -7168,7 +7603,8 @@
             "spe": 23
         },
         "name": "Bronzor",
-        "color": "Green"
+        "color": "Green",
+        "gender": null
     },
     {
         "id": 437,
@@ -7185,7 +7621,8 @@
             "spe": 33
         },
         "name": "Bronzong",
-        "color": "Green"
+        "color": "Green",
+        "gender": null
     },
     {
         "id": 438,
@@ -7201,7 +7638,8 @@
             "spe": 10
         },
         "name": "Bonsly",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 439,
@@ -7217,7 +7655,8 @@
             "spe": 60
         },
         "name": "Mime Jr.",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 440,
@@ -7233,7 +7672,8 @@
             "spe": 30
         },
         "name": "Happiny",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "f"
     },
     {
         "id": 441,
@@ -7250,7 +7690,8 @@
             "spe": 91
         },
         "name": "Chatot",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 442,
@@ -7267,7 +7708,8 @@
             "spe": 35
         },
         "name": "Spiritomb",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 443,
@@ -7284,7 +7726,8 @@
             "spe": 42
         },
         "name": "Gible",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 444,
@@ -7301,7 +7744,8 @@
             "spe": 82
         },
         "name": "Gabite",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 445,
@@ -7318,7 +7762,8 @@
             "spe": 102
         },
         "name": "Garchomp",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 446,
@@ -7334,7 +7779,8 @@
             "spe": 5
         },
         "name": "Munchlax",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 447,
@@ -7350,7 +7796,8 @@
             "spe": 60
         },
         "name": "Riolu",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 448,
@@ -7367,7 +7814,8 @@
             "spe": 90
         },
         "name": "Lucario",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 449,
@@ -7383,7 +7831,8 @@
             "spe": 32
         },
         "name": "Hippopotas",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 450,
@@ -7399,7 +7848,8 @@
             "spe": 47
         },
         "name": "Hippowdon",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 451,
@@ -7416,7 +7866,8 @@
             "spe": 65
         },
         "name": "Skorupi",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 452,
@@ -7433,7 +7884,8 @@
             "spe": 95
         },
         "name": "Drapion",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 453,
@@ -7450,7 +7902,8 @@
             "spe": 50
         },
         "name": "Croagunk",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 454,
@@ -7467,7 +7920,8 @@
             "spe": 85
         },
         "name": "Toxicroak",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 455,
@@ -7483,7 +7937,8 @@
             "spe": 46
         },
         "name": "Carnivine",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 456,
@@ -7499,7 +7954,8 @@
             "spe": 66
         },
         "name": "Finneon",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 457,
@@ -7515,7 +7971,8 @@
             "spe": 91
         },
         "name": "Lumineon",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 458,
@@ -7532,7 +7989,8 @@
             "spe": 50
         },
         "name": "Mantyke",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 459,
@@ -7549,7 +8007,8 @@
             "spe": 40
         },
         "name": "Snover",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 460,
@@ -7566,7 +8025,8 @@
             "spe": 60
         },
         "name": "Abomasnow",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 461,
@@ -7583,7 +8043,8 @@
             "spe": 125
         },
         "name": "Weavile",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 462,
@@ -7600,7 +8061,8 @@
             "spe": 60
         },
         "name": "Magnezone",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": null
     },
     {
         "id": 463,
@@ -7616,7 +8078,8 @@
             "spe": 50
         },
         "name": "Lickilicky",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": "mf"
     },
     {
         "id": 464,
@@ -7633,7 +8096,8 @@
             "spe": 40
         },
         "name": "Rhyperior",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 465,
@@ -7649,7 +8113,8 @@
             "spe": 50
         },
         "name": "Tangrowth",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 466,
@@ -7665,7 +8130,8 @@
             "spe": 95
         },
         "name": "Electivire",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "mf"
     },
     {
         "id": 467,
@@ -7681,7 +8147,8 @@
             "spe": 83
         },
         "name": "Magmortar",
-        "color": "Red"
+        "color": "Red",
+        "gender": "mf"
     },
     {
         "id": 468,
@@ -7698,7 +8165,8 @@
             "spe": 80
         },
         "name": "Togekiss",
-        "color": "White"
+        "color": "White",
+        "gender": "mf"
     },
     {
         "id": 469,
@@ -7715,7 +8183,8 @@
             "spe": 95
         },
         "name": "Yanmega",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 470,
@@ -7731,7 +8200,8 @@
             "spe": 95
         },
         "name": "Leafeon",
-        "color": "Green"
+        "color": "Green",
+        "gender": "mf"
     },
     {
         "id": 471,
@@ -7747,7 +8217,8 @@
             "spe": 65
         },
         "name": "Glaceon",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": "mf"
     },
     {
         "id": 472,
@@ -7764,7 +8235,8 @@
             "spe": 95
         },
         "name": "Gliscor",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": "mf"
     },
     {
         "id": 473,
@@ -7781,7 +8253,8 @@
             "spe": 80
         },
         "name": "Mamoswine",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 474,
@@ -7797,7 +8270,8 @@
             "spe": 90
         },
         "name": "Porygon-Z",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 475,
@@ -7814,7 +8288,8 @@
             "spe": 80
         },
         "name": "Gallade",
-        "color": "White"
+        "color": "White",
+        "gender": "m"
     },
     {
         "id": 476,
@@ -7831,7 +8306,8 @@
             "spe": 40
         },
         "name": "Probopass",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": "mf"
     },
     {
         "id": 477,
@@ -7847,7 +8323,8 @@
             "spe": 45
         },
         "name": "Dusknoir",
-        "color": "Black"
+        "color": "Black",
+        "gender": "mf"
     },
     {
         "id": 478,
@@ -7864,7 +8341,8 @@
             "spe": 110
         },
         "name": "Froslass",
-        "color": "White"
+        "color": "White",
+        "gender": "f"
     },
     {
         "id": 479,
@@ -7881,7 +8359,8 @@
             "spe": 91
         },
         "name": "Rotom",
-        "color": "Red"
+        "color": "Red",
+        "gender": null
     },
     {
         "id": 480,
@@ -7897,7 +8376,8 @@
             "spe": 95
         },
         "name": "Uxie",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": null
     },
     {
         "id": 481,
@@ -7913,7 +8393,8 @@
             "spe": 80
         },
         "name": "Mesprit",
-        "color": "Pink"
+        "color": "Pink",
+        "gender": null
     },
     {
         "id": 482,
@@ -7929,7 +8410,8 @@
             "spe": 115
         },
         "name": "Azelf",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 483,
@@ -7946,7 +8428,8 @@
             "spe": 90
         },
         "name": "Dialga",
-        "color": "White"
+        "color": "White",
+        "gender": null
     },
     {
         "id": 484,
@@ -7963,7 +8446,8 @@
             "spe": 100
         },
         "name": "Palkia",
-        "color": "Purple"
+        "color": "Purple",
+        "gender": null
     },
     {
         "id": 485,
@@ -7980,7 +8464,8 @@
             "spe": 77
         },
         "name": "Heatran",
-        "color": "Brown"
+        "color": "Brown",
+        "gender": "mf"
     },
     {
         "id": 486,
@@ -7996,7 +8481,8 @@
             "spe": 100
         },
         "name": "Regigigas",
-        "color": "White"
+        "color": "White",
+        "gender": null
     },
     {
         "id": 487,
@@ -8013,7 +8499,8 @@
             "spe": 90
         },
         "name": "Giratina",
-        "color": "Black"
+        "color": "Black",
+        "gender": null
     },
     {
         "id": 488,
@@ -8029,7 +8516,8 @@
             "spe": 85
         },
         "name": "Cresselia",
-        "color": "Yellow"
+        "color": "Yellow",
+        "gender": "f"
     },
     {
         "id": 489,
@@ -8045,7 +8533,8 @@
             "spe": 80
         },
         "name": "Phione",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 490,
@@ -8061,7 +8550,8 @@
             "spe": 100
         },
         "name": "Manaphy",
-        "color": "Blue"
+        "color": "Blue",
+        "gender": null
     },
     {
         "id": 491,
@@ -8077,7 +8567,8 @@
             "spe": 125
         },
         "name": "Darkrai",
-        "color": "Black"
+        "color": "Black",
+        "gender": null
     },
     {
         "id": 492,
@@ -8093,7 +8584,8 @@
             "spe": 100
         },
         "name": "Shaymin",
-        "color": "Green"
+        "color": "Green",
+        "gender": null
     },
     {
         "id": 493,
@@ -8109,6 +8601,7 @@
             "spe": 120
         },
         "name": "Arceus",
-        "color": "Gray"
+        "color": "Gray",
+        "gender": null
     }
 ]

--- a/pokecat_test.py
+++ b/pokecat_test.py
@@ -256,6 +256,11 @@ class PokecatTester(unittest.TestCase):
         result = pokecat.populate_pokeset(doc)
         self.assertEqual(result["gender"], ["m", "f"])
 
+    def test_default_gender(self):
+        doc = load_test_doc("_template")
+        result = pokecat.populate_pokeset(doc)
+        self.assertEqual(result["gender"], ["m", "f"])
+
     def test_duplicate_gender_list(self):
         doc = load_test_doc("_template")
         doc["gender"] = ["m", "m"]
@@ -268,10 +273,22 @@ class PokecatTester(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"gender can only be 'm', 'f' or not set \(null\), but not w"):
             pokecat.populate_pokeset(doc)
 
-    def test_mixed_genders(self):
+    def test_wrong_genders(self):
         doc = load_test_doc("_template")
         doc["gender"] = ["m", None]
-        with self.assertRaisesRegex(ValueError, r"non-gender cannot be mixed with m/f"):
+        with self.assertRaisesRegex(ValueError, r"Invalid gender for Bulbasaur"):
+            pokecat.populate_pokeset(doc)
+        doc["species"] = "Tyrogue"
+        doc["gender"] = "f"
+        with self.assertRaisesRegex(ValueError, r"Invalid gender for Tyrogue"):
+            pokecat.populate_pokeset(doc)
+        doc["species"] = "Chansey"
+        doc["gender"] = ["m", "f"]
+        with self.assertRaisesRegex(ValueError, r"Invalid gender for Chansey"):
+            pokecat.populate_pokeset(doc)
+        doc["species"] = "Beldum"
+        doc["gender"] = ["m"]
+        with self.assertRaisesRegex(ValueError, r"Invalid gender for Beldum"):
             pokecat.populate_pokeset(doc)
 
     def test_level(self):

--- a/pokesetspec.md
+++ b/pokesetspec.md
@@ -5,7 +5,7 @@ This document specifies the format in which Pokémon sets are defined for Twitch
 
 ## Requirements
 
-The format must be easily understandable and usable by people not adept in programming or similar technical tasks. This implies error tolerance against common mistakes such as: 
+The format must be easily understandable and usable by people not adept in programming or similar technical tasks. This implies error tolerance against common mistakes such as:
 - additional whitespace
 - spelling errors
 - wrong case-sensitivity
@@ -82,11 +82,11 @@ All Pokémon, items and abilities must be from 4th generation or earlier, becaus
 
 **nature**
   : The Pokémon's nature. Can either be a nature name, a nature number (0 = Hardy, 24 = Quirky) or a nature defined by boosted and nerfed stat (for example `+atk -spD`)
-  
+
 **ivs**
   : The Pokémon's Individual Values. Can either be a single number (e.g. `0`) to be the same for all stats, or a dictionary containing a value for each stat (`hp`, `atk`, `def`, `spe`, `spA` and `spD`).
   : *Note:* An inline dictionary consists of comma-separated `key:value` pairs enclosed in curly braces, like in the example.
-  
+
 **evs**
   : Same as *IVs*, but for Effort Values. The sum of all values cannot exceed 510, and one single stat cannot have more than 252 EVs.
 
@@ -102,8 +102,7 @@ All Pokémon, items and abilities must be from 4th generation or earlier, becaus
   : Name the Pokémon has ingame. Defaults to the Species' name in uppercase. Maximum of 10 characters, therefore the default might have a shortened species name (e.g. `CRABOMINAB` for Crabominable). Can only contain ASCII characters and the male/female sign.  Note the ingamename might be altered automatically when used in a match (e.g. appending numbers to make it unique, if there is a technical limitation that Pokémon with the same ingame name cannot be in the same match).
 
 **gender**
-  : Defaults to null (no gender). Can also be "m" and "f", or a *list of genders* (e.g. `[m, f]`) to let RNG decide.
-  : *Note:* Mixing male and female with no gender in the same species can crash PBR. For each species (therefore also across all set for that species) agree on sticking to whether that species is genderless or not.
+  : Defaults to all possible genders of the species. Can be `null`, `m`, `f` for sets that should only be one gender, or `[m, f]` to let RNG decide. `mf` is automatically expanded to `[m, f]`.
 
 **form**
   : Defaults to `0`. Can be a form number, or a form name specific to a given Pokémon. The following form names are valid:  
@@ -131,7 +130,7 @@ All Pokémon, items and abilities must be from 4th generation or earlier, becaus
   : Defaults to `true`, except for Pokémon with `shiny` set to `true`, where it defaults to `false`. If `false`, the Pokémon is not available for token match bidding.
 
 **hidden**
-  : Defaults to `false`, except for Pokémon with `shiny` set to `true`, where it defaults to `true`. If `true`, the Pokémon will be treated as non-existent, conceiling its existence. Can be used to not spoil Shinies for example.
+  : Defaults to `false`, except for Pokémon with `shiny` set to `true`, where it defaults to `true`. If `true`, the Pokémon will be treated as non-existent, concealing its existence. Can be used to not spoil Shinies for example.
 
 **rarity**
   : Defaults to `1.0`. Multiplier for the chance this set gets chosen by RNG, relative to other sets of the same species. Values smaller than `1.0` cause this set to be selected less often. Values greater than `1.0` cause this set to be selected more often. For example `2.0` doubles this set's chance to get picked.
@@ -165,7 +164,7 @@ All Pokémon, items and abilities must be from 4th generation or earlier, becaus
   - `setname+Standard` if the pokeset's setname is Standard. `Standard` can be any setname respectively.
     The name will be normalized, which usually means lowercase with spaces replaced by `-` and other special characters removed.
   - `matchmaker-enabled` if the rarity is above 0.
-  - `ability+Levitate` if the pokeset's ability has the levitate ability as an option. `Levitate` can be any ability respectively. If multiple abilities are avalible, the resulting mon(s) may not have the ability on the tag you filtered by.
+  - `ability+Levitate` if the pokeset's ability has the levitate ability as an option. `Levitate` can be any ability respectively. If multiple abilities are available, the resulting mon(s) may not have the ability on the tag you filtered by.
 
 **suppressions**
   : A list of suppressions. These can be used to suppress certain warnings pokecat emits.
@@ -173,7 +172,7 @@ All Pokémon, items and abilities must be from 4th generation or earlier, becaus
   - `invalid-evs` suppresses warnings for too many EVs. This affects sets with over 510 EVs total,
     or more than 252 for one stat.
   - `wasted-evs` suppresses warnings for EVs that are not a multiple of 4.
-  - `duplicate-moves` suppresses warnings for the same move occuring in multiple move slots.
-    This is a warning in the first place because PBR only ever deducts and checks PP from the topmost occurance of a move.
-    If the topmost occurance has no PP left, the other slots can still be selected, but the move will fail.
+  - `duplicate-moves` suppresses warnings for the same move occurring in multiple move slots.
+    This is a warning in the first place because PBR only ever deducts and checks PP from the topmost occurrence of a move.
+    If the topmost occurrence has no PP left, the other slots can still be selected, but the move will fail.
   - `public-shiny` suppresses warnings about a shiny set being biddable and/or visible (not hidden).

--- a/unified_objects.md
+++ b/unified_objects.md
@@ -1,9 +1,9 @@
 
 # Standardized data objects for Twitch Plays Pokémon
 
-This document specifies how various data objects should be structured and named, mainly accross Twitch Plays Pokémon applications. It is not meant to be a complete standard, but rather fulfill the needs of TPP. Therefore the available fields are stripped down to only include the most used fields. Its goal is to standardize those conventions to enable Pokémon data to be submitted cross-application. The structures are defined in commented JSON. If this standard is insufficient for you, try orienting yourself after the names [Smogon](http://www.smogon.com/) or [pokeapi.co](http://pokeapi.co/) uses.
+This document specifies how various data objects should be structured and named, mainly across Twitch Plays Pokémon applications. It is not meant to be a complete standard, but rather fulfill the needs of TPP. Therefore the available fields are stripped down to only include the most used fields. Its goal is to standardize those conventions to enable Pokémon data to be submitted cross-application. The structures are defined in commented JSON. If this standard is insufficient for you, try orienting yourself after the names [Smogon](http://www.smogon.com/) or [pokeapi.co](http://pokeapi.co/) uses.
 
-Which fields are optional and which arent is to be decided by the application utilizing this standard. There also is no localization, everything is in english.
+Which fields are optional and which aren't is to be decided by the application utilizing this standard. There also is no localization, everything is in English.
 
 ## Species
 
@@ -14,7 +14,8 @@ A `Species` object describes a Pokémon species. This object is deliberately not
     "id": 1,                      # National Pokédex number of that Pokémon
     "name": "Bulbasaur",          # english name of the species
     "basestats": [Stats object],  # base stats of that species
-    "types": [Type objects ...]   # base types of that species, length 1 or 2
+    "types": [Type objects ...],  # base types of that species, length 1 or 2
+    "gender": [Gender object]     # possible genders of that species
 }
 ```
 
@@ -103,14 +104,14 @@ Data for `Item` objects may vary between different generations and/or games.
 
 ## Move
 
-Data for `Move` objects may vary between different generations and/or games. 
+Data for `Move` objects may vary between different generations and/or games.
 
 ```
 {
     "id": 1,             # ID of that move, same as game-internal ID
     "name_id": "pound",  # simplyfied string-representation of that move*
     "category": [Category object],  # category of that move. Can be "Physical", "Special" and "Status"
-    "type": [Type object],          # type of that move 
+    "type": [Type object],          # type of that move
     "accuracy": 100,     # base accuracy of that move. between 0 and 100, and can also be null (no accuracy)
     "name": "Pound",     # english name of that move
     "power": 40,         # base power of that move, minimum 0
@@ -139,6 +140,4 @@ If indices are needed, use the list above.
 
 ## Gender
 
-A `Gender` is defined as a single-character string. A gender can either be `"m"` or `"f"`. The preferred representation for "no gender" is `null`. If that isn't an option, the preferred alternative is `"-"`.
-
-
+A `Gender` is defined as a lowercased string of either `"m"`, `"f"`, or `"mf"` (denoting the Pokémon can be either gender). It can also be `null` (denoting no gender). If `null` is unsupported, instead use the string `"-"`.

--- a/unified_objects.md
+++ b/unified_objects.md
@@ -15,7 +15,7 @@ A `Species` object describes a Pokémon species. This object is deliberately not
     "name": "Bulbasaur",          # english name of the species
     "basestats": [Stats object],  # base stats of that species
     "types": [Type objects ...],  # base types of that species, length 1 or 2
-    "gender": [Gender object]     # possible genders of that species
+    "genders": [Gender objects ...] # possible genders of that species
 }
 ```
 
@@ -140,4 +140,4 @@ If indices are needed, use the list above.
 
 ## Gender
 
-A `Gender` is defined as a lowercased string of either `"m"`, `"f"`, or `"mf"` (denoting the Pokémon can be either gender). It can also be `null` (denoting no gender). If `null` is unsupported, instead use the string `"-"`.
+A `Gender` is defined as a single-character string. It can be either `"m"` or `"f"`. The preferred representation for "no gender" is `null`. If that isn't an option, the preferred alternative is `"-"`.


### PR DESCRIPTION
This addresses #8 .

A brief overview of the changes:
* The possible gender(s) a Pokemon can have are now stored in its `Species` under the key `gender`
* The `gender` field in a pokeset now defaults to all possible genders of that species.
* `mf` is a new option for the `gender` field that automatically expands to `[m, f]`
* The populator now checks that the Pokemon does not have a gender that it shouldn't have

Some examples of how sets are handled under the new system:
```yaml
species: Bulbasaur
gender: mf # Valid
---
species: Bulbasaur
gender: m # Valid
---
species: Bulbasaur # No explicit gender, valid (and recommended for most cases!)
---
species: Bulbasaur
gender: null # Valid, but discouraged; just do the above
---
species: Tyrogue
gender: f # Invalid, can only be male
---
species: Chansey
gender: [m, f] # Invalid, can only be female
---
species: Beldum
gender: mf # Invalid, can't have a gender
```